### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/101/748/155/101748155.geojson
+++ b/data/101/748/155/101748155.geojson
@@ -409,6 +409,9 @@
         "qs_pg:id":1086552
     },
     "wof:country":"EE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fc69dfdcc206e74fb8bdbf36beb34a11",
     "wof:hierarchy":[
         {
@@ -422,7 +425,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566585235,
+    "wof:lastmodified":1582352215,
     "wof:name":"Narva",
     "wof:parent_id":85683059,
     "wof:placetype":"locality",

--- a/data/101/748/157/101748157.geojson
+++ b/data/101/748/157/101748157.geojson
@@ -340,6 +340,9 @@
         "wk:page":"Kohtla-J\u00e4rve"
     },
     "wof:country":"EE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7854d1b98724e07477966729bb2c337f",
     "wof:hierarchy":[
         {
@@ -353,7 +356,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566585234,
+    "wof:lastmodified":1582352215,
     "wof:name":"Kohtla-J\u00e4rve",
     "wof:parent_id":85683059,
     "wof:placetype":"locality",

--- a/data/101/758/373/101758373.geojson
+++ b/data/101/758/373/101758373.geojson
@@ -130,6 +130,9 @@
         "qs_pg:id":907818
     },
     "wof:country":"EE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"224ef36f5a6ef3aa53ce7965276742aa",
     "wof:hierarchy":[
         {
@@ -140,7 +143,7 @@
         }
     ],
     "wof:id":101758373,
-    "wof:lastmodified":1566585236,
+    "wof:lastmodified":1582352215,
     "wof:name":"Viimsi",
     "wof:parent_id":85683055,
     "wof:placetype":"locality",

--- a/data/101/815/063/101815063.geojson
+++ b/data/101/815/063/101815063.geojson
@@ -195,6 +195,9 @@
         "wk:page":"Otep\u00e4\u00e4"
     },
     "wof:country":"EE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"43afcecbddf2a7d2b645163fc3c6ff7d",
     "wof:hierarchy":[
         {
@@ -208,7 +211,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566585240,
+    "wof:lastmodified":1582352215,
     "wof:name":"Otep\u00e4\u00e4",
     "wof:parent_id":85682941,
     "wof:placetype":"locality",

--- a/data/101/815/069/101815069.geojson
+++ b/data/101/815/069/101815069.geojson
@@ -152,6 +152,9 @@
         "wk:page":"R\u00e4pina"
     },
     "wof:country":"EE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f67c4effeae4f3c768bb46de977dcb51",
     "wof:hierarchy":[
         {
@@ -165,7 +168,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566585245,
+    "wof:lastmodified":1582352216,
     "wof:name":"R\u00e4pina",
     "wof:parent_id":85682955,
     "wof:placetype":"locality",

--- a/data/101/815/071/101815071.geojson
+++ b/data/101/815/071/101815071.geojson
@@ -215,6 +215,9 @@
         "wk:page":"P\u00f5lva"
     },
     "wof:country":"EE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"aeb3885531eed057715a7c0b03533b44",
     "wof:hierarchy":[
         {
@@ -228,7 +231,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566585239,
+    "wof:lastmodified":1582352215,
     "wof:name":"P\u00f5lva",
     "wof:parent_id":85682955,
     "wof:placetype":"locality",

--- a/data/101/815/081/101815081.geojson
+++ b/data/101/815/081/101815081.geojson
@@ -178,6 +178,9 @@
         "wk:page":"V\u00f5hma"
     },
     "wof:country":"EE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8820c14fc3953ddd15eb613a55c5210f",
     "wof:hierarchy":[
         {
@@ -191,7 +194,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566585244,
+    "wof:lastmodified":1582352216,
     "wof:name":"V\u00f5hma",
     "wof:parent_id":85682985,
     "wof:placetype":"locality",

--- a/data/101/815/085/101815085.geojson
+++ b/data/101/815/085/101815085.geojson
@@ -146,6 +146,9 @@
         "wk:page":"Suure-Jaani"
     },
     "wof:country":"EE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3e4b075eea9ed673c94438ec8fbc5d1e",
     "wof:hierarchy":[
         {
@@ -159,7 +162,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566585239,
+    "wof:lastmodified":1582352215,
     "wof:name":"Suure-Jaani",
     "wof:parent_id":85682985,
     "wof:placetype":"locality",

--- a/data/101/815/087/101815087.geojson
+++ b/data/101/815/087/101815087.geojson
@@ -97,6 +97,9 @@
         "wk:page":"Viiratsi"
     },
     "wof:country":"EE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b597bd142e62978fe5543e7717f62b3a",
     "wof:hierarchy":[
         {
@@ -110,7 +113,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566585244,
+    "wof:lastmodified":1582352216,
     "wof:name":"Viiratsi",
     "wof:parent_id":85682985,
     "wof:placetype":"locality",

--- a/data/101/815/089/101815089.geojson
+++ b/data/101/815/089/101815089.geojson
@@ -372,6 +372,9 @@
         "wk:page":"Viljandi"
     },
     "wof:country":"EE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6ab91eca05a128e146ad1f5b579c7e0a",
     "wof:hierarchy":[
         {
@@ -385,7 +388,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566585243,
+    "wof:lastmodified":1582352216,
     "wof:name":"Viljandi",
     "wof:parent_id":85682985,
     "wof:placetype":"locality",

--- a/data/101/815/111/101815111.geojson
+++ b/data/101/815/111/101815111.geojson
@@ -169,6 +169,9 @@
         "wd:id":"Q842021"
     },
     "wof:country":"EE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"98e8c5293e59e16443a51a665c3fc406",
     "wof:hierarchy":[
         {
@@ -182,7 +185,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566585241,
+    "wof:lastmodified":1582352215,
     "wof:name":"Mustvee",
     "wof:parent_id":85683009,
     "wof:placetype":"locality",

--- a/data/101/815/113/101815113.geojson
+++ b/data/101/815/113/101815113.geojson
@@ -116,6 +116,9 @@
         "wk:page":"Tabivere Parish"
     },
     "wof:country":"EE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d1a1189d26c34a542d56525121df4ce3",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":101815113,
-    "wof:lastmodified":1566585247,
+    "wof:lastmodified":1582352216,
     "wof:name":"Tabivere",
     "wof:parent_id":85683009,
     "wof:placetype":"locality",

--- a/data/101/815/115/101815115.geojson
+++ b/data/101/815/115/101815115.geojson
@@ -205,6 +205,9 @@
         "wd:id":"Q117513"
     },
     "wof:country":"EE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7f8f097b446b96ca5155bddb9a7fee2c",
     "wof:hierarchy":[
         {
@@ -215,7 +218,7 @@
         }
     ],
     "wof:id":101815115,
-    "wof:lastmodified":1566585246,
+    "wof:lastmodified":1582352216,
     "wof:name":"J\u00f5geva",
     "wof:parent_id":85683009,
     "wof:placetype":"locality",

--- a/data/101/815/117/101815117.geojson
+++ b/data/101/815/117/101815117.geojson
@@ -195,6 +195,9 @@
         "wk:page":"P\u00f5ltsamaa"
     },
     "wof:country":"EE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1b89dd3bd2862b61900951396e9facb2",
     "wof:hierarchy":[
         {
@@ -208,7 +211,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566585242,
+    "wof:lastmodified":1582352215,
     "wof:name":"P\u00f5ltsamaa",
     "wof:parent_id":85683009,
     "wof:placetype":"locality",

--- a/data/101/815/121/101815121.geojson
+++ b/data/101/815/121/101815121.geojson
@@ -123,6 +123,9 @@
         "qs_pg:id":125910
     },
     "wof:country":"EE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"72be11fe46d13effbd75d1769dca058a",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
         }
     ],
     "wof:id":101815121,
-    "wof:lastmodified":1566585241,
+    "wof:lastmodified":1582352215,
     "wof:name":"J\u00e4rvakandi",
     "wof:parent_id":85683013,
     "wof:placetype":"locality",

--- a/data/101/815/123/101815123.geojson
+++ b/data/101/815/123/101815123.geojson
@@ -126,6 +126,9 @@
         "wk:page":"Kohila Parish"
     },
     "wof:country":"EE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f10dba29af3b34be935bb3cf8b1055d2",
     "wof:hierarchy":[
         {
@@ -139,7 +142,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566585246,
+    "wof:lastmodified":1582352216,
     "wof:name":"Kohila",
     "wof:parent_id":85683013,
     "wof:placetype":"locality",

--- a/data/101/815/125/101815125.geojson
+++ b/data/101/815/125/101815125.geojson
@@ -109,6 +109,9 @@
         "wd:id":"Q3477357"
     },
     "wof:country":"EE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"82fd5b5cf155e06d347a28befc1c1199",
     "wof:hierarchy":[
         {
@@ -122,7 +125,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566585247,
+    "wof:lastmodified":1582352216,
     "wof:name":"Kehtna",
     "wof:parent_id":85683013,
     "wof:placetype":"locality",

--- a/data/101/815/127/101815127.geojson
+++ b/data/101/815/127/101815127.geojson
@@ -124,6 +124,9 @@
         "wd:id":"Q2511250"
     },
     "wof:country":"EE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c1f99fd74edda69a8eb05d4947b469d6",
     "wof:hierarchy":[
         {
@@ -137,7 +140,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566585241,
+    "wof:lastmodified":1582352215,
     "wof:name":"M\u00e4rjamaa",
     "wof:parent_id":85683013,
     "wof:placetype":"locality",

--- a/data/101/815/129/101815129.geojson
+++ b/data/101/815/129/101815129.geojson
@@ -209,6 +209,9 @@
         "wk:page":"Rapla"
     },
     "wof:country":"EE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1abb5d9e183b5162768a281d5fcc9fd1",
     "wof:hierarchy":[
         {
@@ -222,7 +225,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566585241,
+    "wof:lastmodified":1582352215,
     "wof:name":"Rapla",
     "wof:parent_id":85683013,
     "wof:placetype":"locality",

--- a/data/101/815/131/101815131.geojson
+++ b/data/101/815/131/101815131.geojson
@@ -110,6 +110,9 @@
         "wd:id":"Q2028864"
     },
     "wof:country":"EE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c6db48ad53e0cfd7a399747075b65f7b",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566585242,
+    "wof:lastmodified":1582352215,
     "wof:name":"J\u00e4rva-Jaani",
     "wof:parent_id":85683031,
     "wof:placetype":"locality",

--- a/data/101/815/133/101815133.geojson
+++ b/data/101/815/133/101815133.geojson
@@ -120,6 +120,9 @@
         "wd:id":"Q2604576"
     },
     "wof:country":"EE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3fbb489e6400ce03281821f5de53f83f",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566585237,
+    "wof:lastmodified":1582352215,
     "wof:name":"Koeru",
     "wof:parent_id":85683031,
     "wof:placetype":"locality",

--- a/data/101/815/135/101815135.geojson
+++ b/data/101/815/135/101815135.geojson
@@ -236,6 +236,9 @@
         "wk:page":"Paide"
     },
     "wof:country":"EE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7ffc8637e7ca4363d52595a87b782b5a",
     "wof:hierarchy":[
         {
@@ -249,7 +252,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566585236,
+    "wof:lastmodified":1582352215,
     "wof:name":"Paide",
     "wof:parent_id":85683031,
     "wof:placetype":"locality",

--- a/data/101/815/139/101815139.geojson
+++ b/data/101/815/139/101815139.geojson
@@ -95,6 +95,9 @@
         "wk:page":"Aravete"
     },
     "wof:country":"EE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6d1793287e0cfd1efa83af33d60b1cbb",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":101815139,
-    "wof:lastmodified":1566585243,
+    "wof:lastmodified":1582352216,
     "wof:name":"Aravete",
     "wof:parent_id":85683031,
     "wof:placetype":"locality",

--- a/data/101/815/141/101815141.geojson
+++ b/data/101/815/141/101815141.geojson
@@ -187,6 +187,9 @@
         "wk:page":"T\u00fcri"
     },
     "wof:country":"EE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"862506562c8c21914be03affcb53fb45",
     "wof:hierarchy":[
         {
@@ -200,7 +203,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566585247,
+    "wof:lastmodified":1582352216,
     "wof:name":"T\u00fcri",
     "wof:parent_id":85683031,
     "wof:placetype":"locality",

--- a/data/101/815/143/101815143.geojson
+++ b/data/101/815/143/101815143.geojson
@@ -321,6 +321,9 @@
         "qs_pg:id":1349550
     },
     "wof:country":"EE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b0879552314bbde86139e3eb1379376a",
     "wof:hierarchy":[
         {
@@ -331,7 +334,7 @@
         }
     ],
     "wof:id":101815143,
-    "wof:lastmodified":1566585241,
+    "wof:lastmodified":1582352215,
     "wof:name":"Kunda",
     "wof:parent_id":85683049,
     "wof:placetype":"locality",

--- a/data/101/815/145/101815145.geojson
+++ b/data/101/815/145/101815145.geojson
@@ -150,6 +150,9 @@
         "wk:page":"Tamsalu"
     },
     "wof:country":"EE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4c61d56f6b94eb3b68692e9e1e0c1856",
     "wof:hierarchy":[
         {
@@ -163,7 +166,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566585240,
+    "wof:lastmodified":1582352215,
     "wof:name":"Tamsalu",
     "wof:parent_id":85683049,
     "wof:placetype":"locality",

--- a/data/101/815/147/101815147.geojson
+++ b/data/101/815/147/101815147.geojson
@@ -120,6 +120,9 @@
         "wk:page":"Kadrina"
     },
     "wof:country":"EE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"17de722050b12f145edfa00dcf39e702",
     "wof:hierarchy":[
         {
@@ -133,7 +136,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566585247,
+    "wof:lastmodified":1582352216,
     "wof:name":"Kadrina",
     "wof:parent_id":85683049,
     "wof:placetype":"locality",

--- a/data/101/815/149/101815149.geojson
+++ b/data/101/815/149/101815149.geojson
@@ -111,6 +111,9 @@
         "wk:page":"Haljala"
     },
     "wof:country":"EE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9172bef4817185d0d83e573e7678ea2d",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566585248,
+    "wof:lastmodified":1582352216,
     "wof:name":"Haljala",
     "wof:parent_id":85683049,
     "wof:placetype":"locality",

--- a/data/101/815/151/101815151.geojson
+++ b/data/101/815/151/101815151.geojson
@@ -117,6 +117,9 @@
         "wk:page":"V\u00e4ike-Maarja"
     },
     "wof:country":"EE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5ee4cd3ee4b206e03d555d207493526b",
     "wof:hierarchy":[
         {
@@ -130,7 +133,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566585238,
+    "wof:lastmodified":1582352215,
     "wof:name":"V\u00e4ike-Maarja",
     "wof:parent_id":85683049,
     "wof:placetype":"locality",

--- a/data/101/815/153/101815153.geojson
+++ b/data/101/815/153/101815153.geojson
@@ -97,6 +97,9 @@
         "wk:page":"Rakke"
     },
     "wof:country":"EE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0c8629fba1b1d8dd7d4631ea4a92e0d0",
     "wof:hierarchy":[
         {
@@ -110,7 +113,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566585242,
+    "wof:lastmodified":1582352215,
     "wof:name":"Rakke",
     "wof:parent_id":85683049,
     "wof:placetype":"locality",

--- a/data/101/815/157/101815157.geojson
+++ b/data/101/815/157/101815157.geojson
@@ -183,6 +183,9 @@
         "wk:page":"Tapa, Estonia"
     },
     "wof:country":"EE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a0a0adc602926073d6909c64cc2259fe",
     "wof:hierarchy":[
         {
@@ -193,7 +196,7 @@
         }
     ],
     "wof:id":101815157,
-    "wof:lastmodified":1566585236,
+    "wof:lastmodified":1582352215,
     "wof:name":"Tapa",
     "wof:parent_id":85683049,
     "wof:placetype":"locality",

--- a/data/101/815/163/101815163.geojson
+++ b/data/101/815/163/101815163.geojson
@@ -87,6 +87,9 @@
         "wk:page":"Loo, Estonia"
     },
     "wof:country":"EE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f67819dc3d24c18534bb8318517dad05",
     "wof:hierarchy":[
         {
@@ -97,7 +100,7 @@
         }
     ],
     "wof:id":101815163,
-    "wof:lastmodified":1566585243,
+    "wof:lastmodified":1582352215,
     "wof:name":"Loo",
     "wof:parent_id":85683055,
     "wof:placetype":"locality",

--- a/data/101/815/171/101815171.geojson
+++ b/data/101/815/171/101815171.geojson
@@ -170,6 +170,9 @@
         "wk:page":"Loksa"
     },
     "wof:country":"EE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"89565dd4ac1a94eaf64a478b5e58cc5a",
     "wof:hierarchy":[
         {
@@ -180,7 +183,7 @@
         }
     ],
     "wof:id":101815171,
-    "wof:lastmodified":1566585248,
+    "wof:lastmodified":1582352216,
     "wof:name":"Loksa",
     "wof:parent_id":85683055,
     "wof:placetype":"locality",

--- a/data/101/815/189/101815189.geojson
+++ b/data/101/815/189/101815189.geojson
@@ -241,6 +241,9 @@
         "wk:page":"Paldiski"
     },
     "wof:country":"EE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"096916098c6702c156a33cb97efa954a",
     "wof:hierarchy":[
         {
@@ -254,7 +257,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566585240,
+    "wof:lastmodified":1582352215,
     "wof:name":"Paldiski",
     "wof:parent_id":85683055,
     "wof:placetype":"locality",

--- a/data/101/815/195/101815195.geojson
+++ b/data/101/815/195/101815195.geojson
@@ -89,6 +89,9 @@
         "wk:page":"Luige"
     },
     "wof:country":"EE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b4e8ffffc3673f1c5b9cdc78a5fd7af4",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
         }
     ],
     "wof:id":101815195,
-    "wof:lastmodified":1566585237,
+    "wof:lastmodified":1582352215,
     "wof:name":"Luige",
     "wof:parent_id":85683055,
     "wof:placetype":"locality",

--- a/data/101/815/199/101815199.geojson
+++ b/data/101/815/199/101815199.geojson
@@ -86,6 +86,9 @@
         "wk:page":"Voka"
     },
     "wof:country":"EE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"04ce7605f20b7ed5c7971c9545c437d0",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
         }
     ],
     "wof:id":101815199,
-    "wof:lastmodified":1566585243,
+    "wof:lastmodified":1582352216,
     "wof:name":"Voka",
     "wof:parent_id":85683059,
     "wof:placetype":"locality",

--- a/data/101/815/201/101815201.geojson
+++ b/data/101/815/201/101815201.geojson
@@ -190,6 +190,9 @@
         "qs_pg:id":550159
     },
     "wof:country":"EE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f46e533194e9b0b352c4a7e2d430529f",
     "wof:hierarchy":[
         {
@@ -203,7 +206,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566585245,
+    "wof:lastmodified":1582352216,
     "wof:name":"Narva-J\u00f5esuu",
     "wof:parent_id":85683059,
     "wof:placetype":"locality",

--- a/data/101/815/203/101815203.geojson
+++ b/data/101/815/203/101815203.geojson
@@ -167,6 +167,9 @@
         "wk:page":"P\u00fcssi"
     },
     "wof:country":"EE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"96d098c425ddec360d586b175e2235bc",
     "wof:hierarchy":[
         {
@@ -180,7 +183,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566585239,
+    "wof:lastmodified":1582352215,
     "wof:name":"P\u00fcssi",
     "wof:parent_id":85683059,
     "wof:placetype":"locality",

--- a/data/101/815/205/101815205.geojson
+++ b/data/101/815/205/101815205.geojson
@@ -110,6 +110,9 @@
         "wk:page":"Kohtla Parish"
     },
     "wof:country":"EE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"00e4a280ddb2ffb1256a76920c20af22",
     "wof:hierarchy":[
         {
@@ -123,7 +126,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566585240,
+    "wof:lastmodified":1582352215,
     "wof:name":"Kohtla-N\u00f5mme",
     "wof:parent_id":85683059,
     "wof:placetype":"locality",

--- a/data/101/815/207/101815207.geojson
+++ b/data/101/815/207/101815207.geojson
@@ -128,6 +128,9 @@
         "wk:page":"Aseri Parish"
     },
     "wof:country":"EE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"dc23b11373a6da886168f7ff8df465dc",
     "wof:hierarchy":[
         {
@@ -141,7 +144,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566585245,
+    "wof:lastmodified":1582352216,
     "wof:name":"Aseri",
     "wof:parent_id":85683059,
     "wof:placetype":"locality",

--- a/data/101/815/211/101815211.geojson
+++ b/data/101/815/211/101815211.geojson
@@ -220,6 +220,9 @@
         "wk:page":"Sillam\u00e4e"
     },
     "wof:country":"EE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3032299cc8a13d6e6ef9af5e706d3f3c",
     "wof:hierarchy":[
         {
@@ -233,7 +236,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566585238,
+    "wof:lastmodified":1582352215,
     "wof:name":"Sillam\u00e4e",
     "wof:parent_id":85683059,
     "wof:placetype":"locality",

--- a/data/101/815/213/101815213.geojson
+++ b/data/101/815/213/101815213.geojson
@@ -177,6 +177,9 @@
         "wk:page":"Kivi\u00f5li"
     },
     "wof:country":"EE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4ddf00e74959342bd9ee1117f6411b7a",
     "wof:hierarchy":[
         {
@@ -190,7 +193,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566585244,
+    "wof:lastmodified":1582352216,
     "wof:name":"Kivi\u00f5li",
     "wof:parent_id":85683059,
     "wof:placetype":"locality",

--- a/data/101/815/215/101815215.geojson
+++ b/data/101/815/215/101815215.geojson
@@ -230,6 +230,9 @@
         "wk:page":"J\u00f5hvi"
     },
     "wof:country":"EE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"248ff7a15ca36cea6c31097ed399adfd",
     "wof:hierarchy":[
         {
@@ -243,7 +246,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566585244,
+    "wof:lastmodified":1582352216,
     "wof:name":"J\u00f5hvi",
     "wof:parent_id":85683059,
     "wof:placetype":"locality",

--- a/data/101/816/255/101816255.geojson
+++ b/data/101/816/255/101816255.geojson
@@ -163,6 +163,9 @@
         "wk:page":"Antsla"
     },
     "wof:country":"EE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8fffe6517f2a2cbf448ee8f05d39b1cb",
     "wof:hierarchy":[
         {
@@ -176,7 +179,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566585233,
+    "wof:lastmodified":1582352214,
     "wof:name":"Antsla",
     "wof:parent_id":85682937,
     "wof:placetype":"locality",

--- a/data/101/816/257/101816257.geojson
+++ b/data/101/816/257/101816257.geojson
@@ -238,6 +238,9 @@
         "wk:page":"V\u00f5ru"
     },
     "wof:country":"EE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"aafd9a70da79bc6be06003b3d3362419",
     "wof:hierarchy":[
         {
@@ -251,7 +254,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566585232,
+    "wof:lastmodified":1582352214,
     "wof:name":"V\u00f5ru",
     "wof:parent_id":85682937,
     "wof:placetype":"locality",

--- a/data/101/816/259/101816259.geojson
+++ b/data/101/816/259/101816259.geojson
@@ -179,6 +179,9 @@
         "wk:page":"T\u00f5rva"
     },
     "wof:country":"EE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"30da4d3f9305686cf3faadac70ecdc4c",
     "wof:hierarchy":[
         {
@@ -192,7 +195,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566585232,
+    "wof:lastmodified":1582352214,
     "wof:name":"T\u00f5rva",
     "wof:parent_id":85682941,
     "wof:placetype":"locality",

--- a/data/101/816/265/101816265.geojson
+++ b/data/101/816/265/101816265.geojson
@@ -150,6 +150,9 @@
         "wk:page":"Karksi-Nuia"
     },
     "wof:country":"EE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fd634b340521100ef08709df876611d3",
     "wof:hierarchy":[
         {
@@ -163,7 +166,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566585233,
+    "wof:lastmodified":1582352214,
     "wof:name":"Karksi-Nuia",
     "wof:parent_id":85682985,
     "wof:placetype":"locality",

--- a/data/101/816/267/101816267.geojson
+++ b/data/101/816/267/101816267.geojson
@@ -172,6 +172,9 @@
         "wk:page":"M\u00f5isak\u00fcla"
     },
     "wof:country":"EE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fdf4e513d8424d7639b8cbbe9fa290dc",
     "wof:hierarchy":[
         {
@@ -185,7 +188,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566585232,
+    "wof:lastmodified":1582352214,
     "wof:name":"M\u00f5isak\u00fcla",
     "wof:parent_id":85682985,
     "wof:placetype":"locality",

--- a/data/101/816/269/101816269.geojson
+++ b/data/101/816/269/101816269.geojson
@@ -161,6 +161,9 @@
         "wk:page":"Abja-Paluoja"
     },
     "wof:country":"EE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1b9eeab8800eadc191dd1218241b24cc",
     "wof:hierarchy":[
         {
@@ -171,7 +174,7 @@
         }
     ],
     "wof:id":101816269,
-    "wof:lastmodified":1566585233,
+    "wof:lastmodified":1582352214,
     "wof:name":"Abja-Paluoja",
     "wof:parent_id":85682985,
     "wof:placetype":"locality",

--- a/data/101/839/155/101839155.geojson
+++ b/data/101/839/155/101839155.geojson
@@ -99,6 +99,9 @@
         "wk:page":"S\u00f5meru"
     },
     "wof:country":"EE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"44a43da4811ef41b1e5075c02a710e76",
     "wof:hierarchy":[
         {
@@ -112,7 +115,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566585249,
+    "wof:lastmodified":1582352216,
     "wof:name":"S\u00f5meru",
     "wof:parent_id":85683049,
     "wof:placetype":"locality",

--- a/data/101/839/837/101839837.geojson
+++ b/data/101/839/837/101839837.geojson
@@ -250,6 +250,9 @@
         "wk:page":"Rakvere"
     },
     "wof:country":"EE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3a1ca593caa145903b823bca7a063546",
     "wof:hierarchy":[
         {
@@ -263,7 +266,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566585249,
+    "wof:lastmodified":1582352216,
     "wof:name":"Rakvere",
     "wof:parent_id":85683049,
     "wof:placetype":"locality",

--- a/data/101/841/149/101841149.geojson
+++ b/data/101/841/149/101841149.geojson
@@ -238,6 +238,9 @@
         "wk:page":"Valga, Estonia"
     },
     "wof:country":"EE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"82abffc0c6200e43c8cc40c25dc20091",
     "wof:hierarchy":[
         {
@@ -251,7 +254,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566585236,
+    "wof:lastmodified":1582352215,
     "wof:name":"Valga",
     "wof:parent_id":85682941,
     "wof:placetype":"locality",

--- a/data/101/846/687/101846687.geojson
+++ b/data/101/846/687/101846687.geojson
@@ -93,6 +93,9 @@
         "wk:page":"Vinni, Estonia"
     },
     "wof:country":"EE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"04efda3db10c300b058b10271f718837",
     "wof:hierarchy":[
         {
@@ -103,7 +106,7 @@
         }
     ],
     "wof:id":101846687,
-    "wof:lastmodified":1566585236,
+    "wof:lastmodified":1582352215,
     "wof:name":"Vinni",
     "wof:parent_id":85683049,
     "wof:placetype":"locality",

--- a/data/101/911/327/101911327.geojson
+++ b/data/101/911/327/101911327.geojson
@@ -98,6 +98,9 @@
         "wk:page":"K\u00e4smu"
     },
     "wof:country":"EE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9b6d5a7177dd6f661b44dae2dc39ab74",
     "wof:hierarchy":[
         {
@@ -108,7 +111,7 @@
         }
     ],
     "wof:id":101911327,
-    "wof:lastmodified":1566585249,
+    "wof:lastmodified":1582352216,
     "wof:name":"K\u00e4smu",
     "wof:parent_id":85683049,
     "wof:placetype":"locality",

--- a/data/101/912/987/101912987.geojson
+++ b/data/101/912/987/101912987.geojson
@@ -92,6 +92,9 @@
         "qs_pg:id":1086712
     },
     "wof:country":"EE",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7378d0646cd9a13850a6dfc2a629e353",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
         }
     ],
     "wof:id":101912987,
-    "wof:lastmodified":1566585234,
+    "wof:lastmodified":1582352215,
     "wof:name":"P\u00fchaj\u00f5e",
     "wof:parent_id":85683059,
     "wof:placetype":"locality",

--- a/data/856/331/35/85633135.geojson
+++ b/data/856/331/35/85633135.geojson
@@ -1168,6 +1168,11 @@
     },
     "wof:country":"EE",
     "wof:country_alpha3":"EST",
+    "wof:geom_alt":[
+        "naturalearth",
+        "quattroshapes",
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"1a6027e0ce095948c1458e9c84ac1e57",
     "wof:hierarchy":[
         {
@@ -1182,7 +1187,7 @@
     "wof:lang_x_spoken":[
         "est"
     ],
-    "wof:lastmodified":1566584897,
+    "wof:lastmodified":1582352209,
     "wof:name":"Estonia",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/859/014/75/85901475.geojson
+++ b/data/859/014/75/85901475.geojson
@@ -106,6 +106,9 @@
         "qs_pg:id":994388
     },
     "wof:country":"EE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2af6879fb9b2cc4c1439922ae34c14a3",
     "wof:hierarchy":[
         {
@@ -120,7 +123,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566584896,
+    "wof:lastmodified":1582352208,
     "wof:name":"M\u00e4ek\u00fcla",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/014/83/85901483.geojson
+++ b/data/859/014/83/85901483.geojson
@@ -80,6 +80,10 @@
         "qs_pg:id":894610
     },
     "wof:country":"EE",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"31edf4fb67461aad8ff18441fedc1030",
     "wof:hierarchy":[
         {
@@ -94,7 +98,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566584896,
+    "wof:lastmodified":1582352208,
     "wof:name":"Papiaru",
     "wof:parent_id":101839837,
     "wof:placetype":"neighbourhood",

--- a/data/859/014/89/85901489.geojson
+++ b/data/859/014/89/85901489.geojson
@@ -127,6 +127,9 @@
         "wk:page":"Tahkuna"
     },
     "wof:country":"EE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"74211ee75af6bd67dd1968458164302b",
     "wof:hierarchy":[
         {
@@ -141,7 +144,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566584896,
+    "wof:lastmodified":1582352208,
     "wof:name":"Takhkuna",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.