### PR TITLE
Add missing properties to alt files

### DIFF
--- a/data/101/748/149/101748149-alt-quattroshapes.geojson
+++ b/data/101/748/149/101748149-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101748149,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"017d79666e8bb114e73a667968f6d455",
-    "wof:id":101748149
+    "wof:id":101748149,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     24.44567,

--- a/data/101/748/151/101748151-alt-quattroshapes.geojson
+++ b/data/101/748/151/101748151-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101748151,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"8116689ff664b0bff291c1acbddae446",
-    "wof:id":101748151
+    "wof:id":101748151,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     26.670911,

--- a/data/101/748/153/101748153-alt-quattroshapes.geojson
+++ b/data/101/748/153/101748153-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101748153,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"62da0b814407e2b67dac26d7488f9759",
-    "wof:id":101748153
+    "wof:id":101748153,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     24.55554,

--- a/data/101/748/155/101748155-alt-quattroshapes.geojson
+++ b/data/101/748/155/101748155-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101748155,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"61465911a5090ad5103740170f770a6e",
-    "wof:id":101748155
+    "wof:id":101748155,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     28.011411,

--- a/data/101/753/879/101753879-alt-quattroshapes.geojson
+++ b/data/101/753/879/101753879-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101753879,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"673163274534d38cedc5260009f47c31",
-    "wof:id":101753879
+    "wof:id":101753879,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     24.486243,

--- a/data/101/753/881/101753881-alt-quattroshapes.geojson
+++ b/data/101/753/881/101753881-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101753881,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"5f0e3b105be499221442a0064c445fd8",
-    "wof:id":101753881
+    "wof:id":101753881,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     24.527012,

--- a/data/101/753/885/101753885-alt-quattroshapes.geojson
+++ b/data/101/753/885/101753885-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101753885,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"d04329c577c18d94f417fdbb32e9bd4c",
-    "wof:id":101753885
+    "wof:id":101753885,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     24.597913,

--- a/data/101/753/887/101753887-alt-quattroshapes.geojson
+++ b/data/101/753/887/101753887-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101753887,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"0fcede91d44d0837e75fd9afffab1429",
-    "wof:id":101753887
+    "wof:id":101753887,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     24.790727,

--- a/data/101/753/889/101753889-alt-quattroshapes.geojson
+++ b/data/101/753/889/101753889-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101753889,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"7209bed4cb7092386ef8508302e72371",
-    "wof:id":101753889
+    "wof:id":101753889,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     24.880789,

--- a/data/101/753/891/101753891-alt-quattroshapes.geojson
+++ b/data/101/753/891/101753891-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101753891,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"ce00fc0a388230e418f3f9222fd43df7",
-    "wof:id":101753891
+    "wof:id":101753891,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     24.884867,

--- a/data/101/758/373/101758373-alt-quattroshapes.geojson
+++ b/data/101/758/373/101758373-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101758373,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"bb48d94fb81c44802fe5ce461bcfdc80",
-    "wof:id":101758373
+    "wof:id":101758373,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     24.830657,

--- a/data/101/758/375/101758375-alt-quattroshapes.geojson
+++ b/data/101/758/375/101758375-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101758375,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"a93f121028448eed0f06aabb993444df",
-    "wof:id":101758375
+    "wof:id":101758375,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     24.806389,

--- a/data/101/758/377/101758377-alt-quattroshapes.geojson
+++ b/data/101/758/377/101758377-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101758377,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"5bb2d3d481de368ba746dc7d3398b62b",
-    "wof:id":101758377
+    "wof:id":101758377,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     24.789533,

--- a/data/101/758/379/101758379-alt-quattroshapes.geojson
+++ b/data/101/758/379/101758379-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101758379,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"11ef1485edcdc1d800f9c47867ffea1c",
-    "wof:id":101758379
+    "wof:id":101758379,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     24.844915,

--- a/data/101/815/063/101815063-alt-quattroshapes.geojson
+++ b/data/101/815/063/101815063-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101815063,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"b8f73b61a3a2b811adf8cca9fdbb6c47",
-    "wof:id":101815063
+    "wof:id":101815063,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     26.465367,

--- a/data/101/815/067/101815067-alt-quattroshapes.geojson
+++ b/data/101/815/067/101815067-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101815067,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"510d8ead572bd0f0a13db41961d63333",
-    "wof:id":101815067
+    "wof:id":101815067,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     23.064264,

--- a/data/101/815/069/101815069-alt-quattroshapes.geojson
+++ b/data/101/815/069/101815069-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101815069,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"51798598b3328f152d26e2cb27a5b657",
-    "wof:id":101815069
+    "wof:id":101815069,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     27.436652,

--- a/data/101/815/071/101815071-alt-quattroshapes.geojson
+++ b/data/101/815/071/101815071-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101815071,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"c9924adf77eacfa2f90c9203e21fb680",
-    "wof:id":101815071
+    "wof:id":101815071,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     27.032108,

--- a/data/101/815/073/101815073-alt-quattroshapes.geojson
+++ b/data/101/815/073/101815073-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101815073,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"bb056c03401e7bf807d4790e99caa54d",
-    "wof:id":101815073
+    "wof:id":101815073,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     24.489157,

--- a/data/101/815/075/101815075-alt-quattroshapes.geojson
+++ b/data/101/815/075/101815075-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101815075,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"1c2b83c2a69c01ebf09319354e6c6ae8",
-    "wof:id":101815075
+    "wof:id":101815075,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     24.771546,

--- a/data/101/815/077/101815077-alt-quattroshapes.geojson
+++ b/data/101/815/077/101815077-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101815077,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"a002d7fbe396b9480415ae131d989ff6",
-    "wof:id":101815077
+    "wof:id":101815077,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     24.347017,

--- a/data/101/815/079/101815079-alt-quattroshapes.geojson
+++ b/data/101/815/079/101815079-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101815079,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"9dbbc51a6adfa2abd5562ca0668c7bcb",
-    "wof:id":101815079
+    "wof:id":101815079,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     25.010111,

--- a/data/101/815/081/101815081-alt-quattroshapes.geojson
+++ b/data/101/815/081/101815081-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101815081,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"28a3b4847f3c0fc6c725bbd81538817b",
-    "wof:id":101815081
+    "wof:id":101815081,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     25.539204,

--- a/data/101/815/085/101815085-alt-quattroshapes.geojson
+++ b/data/101/815/085/101815085-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101815085,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"f963bf46fe50474a459ec57022f4e226",
-    "wof:id":101815085
+    "wof:id":101815085,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     25.449304,

--- a/data/101/815/087/101815087-alt-quattroshapes.geojson
+++ b/data/101/815/087/101815087-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101815087,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"011995c915a657c4c7a7b602585aacc1",
-    "wof:id":101815087
+    "wof:id":101815087,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     25.628964,

--- a/data/101/815/089/101815089-alt-quattroshapes.geojson
+++ b/data/101/815/089/101815089-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101815089,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"e773db42a2046e683592c57a91dcbc6f",
-    "wof:id":101815089
+    "wof:id":101815089,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     25.558255,

--- a/data/101/815/091/101815091-alt-quattroshapes.geojson
+++ b/data/101/815/091/101815091-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101815091,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"a1338c4c3d4f4c221a22c32ae3b74f4b",
-    "wof:id":101815091
+    "wof:id":101815091,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     25.845375,

--- a/data/101/815/093/101815093-alt-quattroshapes.geojson
+++ b/data/101/815/093/101815093-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101815093,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"83f0e64bde792bb764f980e6b1cf7b36",
-    "wof:id":101815093
+    "wof:id":101815093,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     22.711575,

--- a/data/101/815/095/101815095-alt-quattroshapes.geojson
+++ b/data/101/815/095/101815095-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101815095,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"128b0489e42da0b8d40751f2900585e2",
-    "wof:id":101815095
+    "wof:id":101815095,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     27.151849,

--- a/data/101/815/097/101815097-alt-quattroshapes.geojson
+++ b/data/101/815/097/101815097-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101815097,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"863ba7faede7a9bd9f4f113329d36975",
-    "wof:id":101815097
+    "wof:id":101815097,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     26.296879,

--- a/data/101/815/099/101815099-alt-quattroshapes.geojson
+++ b/data/101/815/099/101815099-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101815099,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"6cdcdda7f278246871c75691462163a2",
-    "wof:id":101815099
+    "wof:id":101815099,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     26.50738,

--- a/data/101/815/103/101815103-alt-quattroshapes.geojson
+++ b/data/101/815/103/101815103-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101815103,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"9cd3cf2cfb29cc61b37f892746a2f7f6",
-    "wof:id":101815103
+    "wof:id":101815103,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     26.381207,

--- a/data/101/815/105/101815105-alt-quattroshapes.geojson
+++ b/data/101/815/105/101815105-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101815105,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"808af5b8b154754411e84354612fda21",
-    "wof:id":101815105
+    "wof:id":101815105,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     23.570243,

--- a/data/101/815/107/101815107-alt-quattroshapes.geojson
+++ b/data/101/815/107/101815107-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101815107,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"cda7c23483fd87642df14e37ddff2856",
-    "wof:id":101815107
+    "wof:id":101815107,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     23.807955,

--- a/data/101/815/109/101815109-alt-quattroshapes.geojson
+++ b/data/101/815/109/101815109-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101815109,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"d4b3a1c5428b43c8da0f599186dc515c",
-    "wof:id":101815109
+    "wof:id":101815109,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     23.510598,

--- a/data/101/815/111/101815111-alt-quattroshapes.geojson
+++ b/data/101/815/111/101815111-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101815111,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"44e015cc65279598f75ac6aed80f750d",
-    "wof:id":101815111
+    "wof:id":101815111,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     26.926687,

--- a/data/101/815/113/101815113-alt-quattroshapes.geojson
+++ b/data/101/815/113/101815113-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101815113,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"b7431a76814141c346e217ace86b9d72",
-    "wof:id":101815113
+    "wof:id":101815113,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     26.58481,

--- a/data/101/815/115/101815115-alt-quattroshapes.geojson
+++ b/data/101/815/115/101815115-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101815115,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"4793e2d26a22983101323e250815dbdc",
-    "wof:id":101815115
+    "wof:id":101815115,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     26.358596,

--- a/data/101/815/117/101815117-alt-quattroshapes.geojson
+++ b/data/101/815/117/101815117-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101815117,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"f6dd74fb74312c938759c9dd8af614ca",
-    "wof:id":101815117
+    "wof:id":101815117,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     25.955589,

--- a/data/101/815/121/101815121-alt-quattroshapes.geojson
+++ b/data/101/815/121/101815121-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101815121,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"d973dbf56f70755a5e5e7876661f14f6",
-    "wof:id":101815121
+    "wof:id":101815121,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     24.797278,

--- a/data/101/815/123/101815123-alt-quattroshapes.geojson
+++ b/data/101/815/123/101815123-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101815123,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"8fc61ea598e1252ccfedf9580e10ba4f",
-    "wof:id":101815123
+    "wof:id":101815123,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     24.728447,

--- a/data/101/815/125/101815125-alt-quattroshapes.geojson
+++ b/data/101/815/125/101815125-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101815125,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"e141691fe31a2c050622e3ad19343e07",
-    "wof:id":101815125
+    "wof:id":101815125,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     24.860087,

--- a/data/101/815/127/101815127-alt-quattroshapes.geojson
+++ b/data/101/815/127/101815127-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101815127,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"8ec8f5cd7e33b547dd85844ef3171ada",
-    "wof:id":101815127
+    "wof:id":101815127,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     24.40848,

--- a/data/101/815/129/101815129-alt-quattroshapes.geojson
+++ b/data/101/815/129/101815129-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101815129,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"5047ad22363401c4e7742170f43be87d",
-    "wof:id":101815129
+    "wof:id":101815129,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     24.770285,

--- a/data/101/815/131/101815131-alt-quattroshapes.geojson
+++ b/data/101/815/131/101815131-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101815131,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"83b7fc250d7b056b2fb99d5306ef2a50",
-    "wof:id":101815131
+    "wof:id":101815131,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     25.871413,

--- a/data/101/815/133/101815133-alt-quattroshapes.geojson
+++ b/data/101/815/133/101815133-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101815133,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"fc4aa9c9cb1f27d7b9de9a2555d1eedf",
-    "wof:id":101815133
+    "wof:id":101815133,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     26.003308,

--- a/data/101/815/135/101815135-alt-quattroshapes.geojson
+++ b/data/101/815/135/101815135-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101815135,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"23cebb41b0d5ae59627879a62343bd31",
-    "wof:id":101815135
+    "wof:id":101815135,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     25.522593,

--- a/data/101/815/139/101815139-alt-quattroshapes.geojson
+++ b/data/101/815/139/101815139-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101815139,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"b8c8cebace6eca4bf490083fb0065efa",
-    "wof:id":101815139
+    "wof:id":101815139,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     25.733795,

--- a/data/101/815/141/101815141-alt-quattroshapes.geojson
+++ b/data/101/815/141/101815141-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101815141,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"fd3597cbedeec1d3fd281bb28fa89802",
-    "wof:id":101815141
+    "wof:id":101815141,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     25.397797,

--- a/data/101/815/143/101815143-alt-quattroshapes.geojson
+++ b/data/101/815/143/101815143-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101815143,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"4e32daed2705746212bef8784c4321bf",
-    "wof:id":101815143
+    "wof:id":101815143,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     26.498696,

--- a/data/101/815/145/101815145-alt-quattroshapes.geojson
+++ b/data/101/815/145/101815145-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101815145,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"71cb7999d30ee516490c2ae8b6250a05",
-    "wof:id":101815145
+    "wof:id":101815145,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     26.086274,

--- a/data/101/815/147/101815147-alt-quattroshapes.geojson
+++ b/data/101/815/147/101815147-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101815147,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"df1f97d161d1226a76fdd523a50441c5",
-    "wof:id":101815147
+    "wof:id":101815147,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     26.113871,

--- a/data/101/815/149/101815149-alt-quattroshapes.geojson
+++ b/data/101/815/149/101815149-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101815149,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"884e34ffbdfdd9b5ab7ea456a4571a86",
-    "wof:id":101815149
+    "wof:id":101815149,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     26.250397,

--- a/data/101/815/151/101815151-alt-quattroshapes.geojson
+++ b/data/101/815/151/101815151-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101815151,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"21d148fb57cc57d629f140501e2ec1ac",
-    "wof:id":101815151
+    "wof:id":101815151,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     26.235823,

--- a/data/101/815/153/101815153-alt-quattroshapes.geojson
+++ b/data/101/815/153/101815153-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101815153,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"89d1bd07f4c539d86cd48bb1a086c8a6",
-    "wof:id":101815153
+    "wof:id":101815153,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     26.226412,

--- a/data/101/815/157/101815157-alt-quattroshapes.geojson
+++ b/data/101/815/157/101815157-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101815157,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"9208c2b0d158ac7fe1c1be64cc633f1c",
-    "wof:id":101815157
+    "wof:id":101815157,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     25.925659,

--- a/data/101/815/159/101815159-alt-quattroshapes.geojson
+++ b/data/101/815/159/101815159-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101815159,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"93059d819d633c801cb128f6e35ab1bc",
-    "wof:id":101815159
+    "wof:id":101815159,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     25.41176,

--- a/data/101/815/161/101815161-alt-quattroshapes.geojson
+++ b/data/101/815/161/101815161-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101815161,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"7fc87e998772ea32d0e0649f8785a84e",
-    "wof:id":101815161
+    "wof:id":101815161,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     25.160226,

--- a/data/101/815/163/101815163-alt-quattroshapes.geojson
+++ b/data/101/815/163/101815163-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101815163,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"76d54ae2c2ed5255b3bdeb1922927604",
-    "wof:id":101815163
+    "wof:id":101815163,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     24.933702,

--- a/data/101/815/165/101815165-alt-quattroshapes.geojson
+++ b/data/101/815/165/101815165-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101815165,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"5d4a5074dad7083463369f6033ee2b36",
-    "wof:id":101815165
+    "wof:id":101815165,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     24.196935,

--- a/data/101/815/167/101815167-alt-quattroshapes.geojson
+++ b/data/101/815/167/101815167-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101815167,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"24b877f09263797b7581167263497335",
-    "wof:id":101815167
+    "wof:id":101815167,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     24.228622,

--- a/data/101/815/169/101815169-alt-quattroshapes.geojson
+++ b/data/101/815/169/101815169-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101815169,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"f054273eb777a1e08e545bf1f5c2227b",
-    "wof:id":101815169
+    "wof:id":101815169,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     25.09382,

--- a/data/101/815/171/101815171-alt-quattroshapes.geojson
+++ b/data/101/815/171/101815171-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101815171,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"41b268befed409d6fedafc3c095aa5a5",
-    "wof:id":101815171
+    "wof:id":101815171,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     25.70175,

--- a/data/101/815/175/101815175-alt-quattroshapes.geojson
+++ b/data/101/815/175/101815175-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101815175,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"3233d33ed45f57acd26af424e44d7e38",
-    "wof:id":101815175
+    "wof:id":101815175,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     25.309476,

--- a/data/101/815/177/101815177-alt-quattroshapes.geojson
+++ b/data/101/815/177/101815177-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101815177,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"00f97baeb838dda2588d02d6f3649fd6",
-    "wof:id":101815177
+    "wof:id":101815177,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     25.052972,

--- a/data/101/815/179/101815179-alt-quattroshapes.geojson
+++ b/data/101/815/179/101815179-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101815179,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"36763fb8a11e399342520d9d5d0d5964",
-    "wof:id":101815179
+    "wof:id":101815179,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     24.303716,

--- a/data/101/815/181/101815181-alt-quattroshapes.geojson
+++ b/data/101/815/181/101815181-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101815181,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"5d2ed0e1df64cd9ac067933a11b12b21",
-    "wof:id":101815181
+    "wof:id":101815181,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     25.155842,

--- a/data/101/815/183/101815183-alt-quattroshapes.geojson
+++ b/data/101/815/183/101815183-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101815183,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"bd278616a4d447c82b41524e1257772f",
-    "wof:id":101815183
+    "wof:id":101815183,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     24.875162,

--- a/data/101/815/185/101815185-alt-quattroshapes.geojson
+++ b/data/101/815/185/101815185-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101815185,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"34d2868d7a87403ca6947058703e9bc0",
-    "wof:id":101815185
+    "wof:id":101815185,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     24.634782,

--- a/data/101/815/187/101815187-alt-quattroshapes.geojson
+++ b/data/101/815/187/101815187-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101815187,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"ddca22dce69f63791a972fcb3c9a8930",
-    "wof:id":101815187
+    "wof:id":101815187,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     24.378626,

--- a/data/101/815/189/101815189-alt-quattroshapes.geojson
+++ b/data/101/815/189/101815189-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101815189,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"edda9c68c8a83eb07d127cc6e702cbb8",
-    "wof:id":101815189
+    "wof:id":101815189,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     24.035482,

--- a/data/101/815/193/101815193-alt-quattroshapes.geojson
+++ b/data/101/815/193/101815193-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101815193,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"5ff16c24406342c6d963f33157e29a39",
-    "wof:id":101815193
+    "wof:id":101815193,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     24.822063,

--- a/data/101/815/195/101815195-alt-quattroshapes.geojson
+++ b/data/101/815/195/101815195-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101815195,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"144e5483e41faddcece9bdf291dc6939",
-    "wof:id":101815195
+    "wof:id":101815195,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     24.763494,

--- a/data/101/815/197/101815197-alt-quattroshapes.geojson
+++ b/data/101/815/197/101815197-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101815197,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"4f76252d7aee477fc5c7afd4c5a4fd3c",
-    "wof:id":101815197
+    "wof:id":101815197,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     24.379021,

--- a/data/101/815/199/101815199-alt-quattroshapes.geojson
+++ b/data/101/815/199/101815199-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101815199,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"c7e1e1fa12874d6a54bec654af373d37",
-    "wof:id":101815199
+    "wof:id":101815199,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     27.560451,

--- a/data/101/815/201/101815201-alt-quattroshapes.geojson
+++ b/data/101/815/201/101815201-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101815201,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"6aaa6e49ed56b8553a60fca9fc694d02",
-    "wof:id":101815201
+    "wof:id":101815201,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     27.988731,

--- a/data/101/815/203/101815203-alt-quattroshapes.geojson
+++ b/data/101/815/203/101815203-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101815203,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"579af334d5e4d8de6dcd3ddf06eae2c4",
-    "wof:id":101815203
+    "wof:id":101815203,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     27.028322,

--- a/data/101/815/205/101815205-alt-quattroshapes.geojson
+++ b/data/101/815/205/101815205-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101815205,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"31a5eb9421dc2c119f8dda545db2c90e",
-    "wof:id":101815205
+    "wof:id":101815205,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     27.180902,

--- a/data/101/815/207/101815207-alt-quattroshapes.geojson
+++ b/data/101/815/207/101815207-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101815207,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"73a6c283e28905e69f440b013735f240",
-    "wof:id":101815207
+    "wof:id":101815207,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     26.855447,

--- a/data/101/815/211/101815211-alt-quattroshapes.geojson
+++ b/data/101/815/211/101815211-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101815211,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"780efa7795670d57067f25172718f4ec",
-    "wof:id":101815211
+    "wof:id":101815211,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     27.716029,

--- a/data/101/815/213/101815213-alt-quattroshapes.geojson
+++ b/data/101/815/213/101815213-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101815213,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"648289680e9d81de602be37f2018bdd8",
-    "wof:id":101815213
+    "wof:id":101815213,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     26.916688,

--- a/data/101/815/215/101815215-alt-quattroshapes.geojson
+++ b/data/101/815/215/101815215-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101815215,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"43dcbe4430636a79c473f52a5632fd6d",
-    "wof:id":101815215
+    "wof:id":101815215,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     27.373374,

--- a/data/101/816/177/101816177-alt-quattroshapes.geojson
+++ b/data/101/816/177/101816177-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101816177,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"8b4dab211c7dfbce5f82d82acc85498f",
-    "wof:id":101816177
+    "wof:id":101816177,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     24.527525,

--- a/data/101/816/255/101816255-alt-quattroshapes.geojson
+++ b/data/101/816/255/101816255-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101816255,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"99a1a3a8ef26a29992a476b07d502d9f",
-    "wof:id":101816255
+    "wof:id":101816255,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     26.510698,

--- a/data/101/816/257/101816257-alt-quattroshapes.geojson
+++ b/data/101/816/257/101816257-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101816257,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"d694dc9e1bdf7fbd7a86c099744e0146",
-    "wof:id":101816257
+    "wof:id":101816257,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     26.962071,

--- a/data/101/816/259/101816259-alt-quattroshapes.geojson
+++ b/data/101/816/259/101816259-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101816259,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"0fe03d1f31797cff7909010fc65be65a",
-    "wof:id":101816259
+    "wof:id":101816259,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     25.901304,

--- a/data/101/816/261/101816261-alt-quattroshapes.geojson
+++ b/data/101/816/261/101816261-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101816261,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"00fc1e627a1a3fc197e0f9f8215fe9d9",
-    "wof:id":101816261
+    "wof:id":101816261,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     22.45439,

--- a/data/101/816/263/101816263-alt-quattroshapes.geojson
+++ b/data/101/816/263/101816263-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101816263,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"dc20a1b14b7030342f99129c7244903a",
-    "wof:id":101816263
+    "wof:id":101816263,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     24.935295,

--- a/data/101/816/265/101816265-alt-quattroshapes.geojson
+++ b/data/101/816/265/101816265-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101816265,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"6a4403f3c66ff32c9d89204af36d01e0",
-    "wof:id":101816265
+    "wof:id":101816265,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     25.533885,

--- a/data/101/816/267/101816267-alt-quattroshapes.geojson
+++ b/data/101/816/267/101816267-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101816267,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"ca4fa522ccc39f0bd280b75f0f193d90",
-    "wof:id":101816267
+    "wof:id":101816267,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     25.173135,

--- a/data/101/816/269/101816269-alt-quattroshapes.geojson
+++ b/data/101/816/269/101816269-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101816269,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"19c8427cb1e5d3b2ade75b8013b442c8",
-    "wof:id":101816269
+    "wof:id":101816269,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     25.335469,

--- a/data/101/839/155/101839155-alt-quattroshapes.geojson
+++ b/data/101/839/155/101839155-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101839155,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"d3cb5e7a9e37304cead10d9eafa589c9",
-    "wof:id":101839155
+    "wof:id":101839155,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     26.391985,

--- a/data/101/839/827/101839827-alt-quattroshapes.geojson
+++ b/data/101/839/827/101839827-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101839827,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"1b247c0164f78b6b0993e74bae38d598",
-    "wof:id":101839827
+    "wof:id":101839827,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     24.604457,

--- a/data/101/839/829/101839829-alt-quattroshapes.geojson
+++ b/data/101/839/829/101839829-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101839829,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"675e88cf086482ca613cdde840133584",
-    "wof:id":101839829
+    "wof:id":101839829,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     24.635232,

--- a/data/101/839/831/101839831-alt-quattroshapes.geojson
+++ b/data/101/839/831/101839831-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101839831,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"adb82ba4e91b39f1a32e6d47c302bf56",
-    "wof:id":101839831
+    "wof:id":101839831,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     26.713334,

--- a/data/101/839/835/101839835-alt-quattroshapes.geojson
+++ b/data/101/839/835/101839835-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101839835,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"c669fb00b044e9450f5f60f7a82840e1",
-    "wof:id":101839835
+    "wof:id":101839835,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     26.690903,

--- a/data/101/839/837/101839837-alt-quattroshapes.geojson
+++ b/data/101/839/837/101839837-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101839837,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"e9d44a21ba995930c847df441da7fdcb",
-    "wof:id":101839837
+    "wof:id":101839837,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     26.326476,

--- a/data/101/841/149/101841149-alt-quattroshapes.geojson
+++ b/data/101/841/149/101841149-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101841149,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"8feaafd53e756f510507fbad342d4b32",
-    "wof:id":101841149
+    "wof:id":101841149,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     26.023781,

--- a/data/101/846/687/101846687-alt-quattroshapes.geojson
+++ b/data/101/846/687/101846687-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101846687,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"d8154bb781bfa8ed0a2dac1ce908c204",
-    "wof:id":101846687
+    "wof:id":101846687,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     26.397395,

--- a/data/101/847/799/101847799-alt-quattroshapes.geojson
+++ b/data/101/847/799/101847799-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101847799,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"5d9363f76cbcd37675ab157481c0d955",
-    "wof:id":101847799
+    "wof:id":101847799,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     24.199972,

--- a/data/101/911/327/101911327-alt-quattroshapes.geojson
+++ b/data/101/911/327/101911327-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101911327,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"ad1325dfbe21c09262a7e44c97b65ffb",
-    "wof:id":101911327
+    "wof:id":101911327,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     25.907018,

--- a/data/101/911/643/101911643-alt-quattroshapes.geojson
+++ b/data/101/911/643/101911643-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101911643,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"fc725e4119439ccf03613ac985221e3b",
-    "wof:id":101911643
+    "wof:id":101911643,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     22.756506,

--- a/data/101/911/715/101911715-alt-quattroshapes.geojson
+++ b/data/101/911/715/101911715-alt-quattroshapes.geojson
@@ -2,9 +2,11 @@
   "id": 101911715,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"quattroshapes",
     "src:geom":"quattroshapes",
     "wof:geomhash":"43438411f507bab8bf463cbe001c4e60",
-    "wof:id":101911715
+    "wof:id":101911715,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     24.83275,

--- a/data/112/576/534/5/1125765345-alt-qs_pg.geojson
+++ b/data/112/576/534/5/1125765345-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"868805b09a900fd3b3447e69bf640f01",
     "wof:id":1125765345
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     27.87472,

--- a/data/112/576/745/9/1125767459-alt-qs_pg.geojson
+++ b/data/112/576/745/9/1125767459-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"6076859f122b0c600f78a3bc2c6af45c",
     "wof:id":1125767459
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     26.48417,

--- a/data/112/580/080/3/1125800803-alt-qs_pg.geojson
+++ b/data/112/580/080/3/1125800803-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"8daefb179081a1da570533e914236062",
     "wof:id":1125800803
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     24.95028,

--- a/data/112/580/923/9/1125809239-alt-qs_pg.geojson
+++ b/data/112/580/923/9/1125809239-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"4a326e1603f9eaeefff7214ae65474f9",
     "wof:id":1125809239
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     24.68889,

--- a/data/112/581/705/3/1125817053-alt-qs_pg.geojson
+++ b/data/112/581/705/3/1125817053-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"d669ea0ab4690caf20aec4d088d266ce",
     "wof:id":1125817053
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     25.70833,

--- a/data/112/581/706/1/1125817061-alt-qs_pg.geojson
+++ b/data/112/581/706/1/1125817061-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"bcf53cb1a7962226507863e0209870c7",
     "wof:id":1125817061
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     26.90972,

--- a/data/112/583/103/9/1125831039-alt-qs_pg.geojson
+++ b/data/112/583/103/9/1125831039-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"88d84e1bafa3efcc91b25802b5c20f7f",
     "wof:id":1125831039
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     25.10361,

--- a/data/112/583/584/9/1125835849-alt-qs_pg.geojson
+++ b/data/112/583/584/9/1125835849-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"a21a4dc6be0c7511db9cdf2a0ba5cb29",
     "wof:id":1125835849
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     27.38167,

--- a/data/112/583/589/7/1125835897-alt-qs_pg.geojson
+++ b/data/112/583/589/7/1125835897-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"b8669d7c52e8681558b7d8a0e2f47592",
     "wof:id":1125835897
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     26.65972,

--- a/data/112/583/970/1/1125839701-alt-qs_pg.geojson
+++ b/data/112/583/970/1/1125839701-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"ffa4702595a7fce67d22d54a733a028a",
     "wof:id":1125839701
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     26.42333,

--- a/data/112/584/037/1/1125840371-alt-qs_pg.geojson
+++ b/data/112/584/037/1/1125840371-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"e99beb637210bfd8a1660cc3473f3c24",
     "wof:id":1125840371
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     28.12528,

--- a/data/112/585/036/1/1125850361-alt-qs_pg.geojson
+++ b/data/112/585/036/1/1125850361-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"241ffa0c172d0e178a26022c07d8380d",
     "wof:id":1125850361
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     24.06,

--- a/data/112/585/136/9/1125851369-alt-qs_pg.geojson
+++ b/data/112/585/136/9/1125851369-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"554e57f71a4586b5098cc839228b8f79",
     "wof:id":1125851369
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     26.60194,

--- a/data/112/585/481/7/1125854817-alt-qs_pg.geojson
+++ b/data/112/585/481/7/1125854817-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"472b426180bbd4f78154a935cc6fc84d",
     "wof:id":1125854817
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     27.63806,

--- a/data/112/585/820/1/1125858201-alt-qs_pg.geojson
+++ b/data/112/585/820/1/1125858201-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"3090bafb5918e9025e5924f7ff2a08ab",
     "wof:id":1125858201
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     26.19222,

--- a/data/112/585/823/7/1125858237-alt-qs_pg.geojson
+++ b/data/112/585/823/7/1125858237-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"5f8c6f292cc712804114a17e5b853e30",
     "wof:id":1125858237
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     25.82306,

--- a/data/112/586/223/7/1125862237-alt-qs_pg.geojson
+++ b/data/112/586/223/7/1125862237-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"3daf9ca734113c7358bd588a342f311f",
     "wof:id":1125862237
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     25.61417,

--- a/data/112/586/686/9/1125866869-alt-qs_pg.geojson
+++ b/data/112/586/686/9/1125866869-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"5795a220ad499fe69d6021b08e1e7e4b",
     "wof:id":1125866869
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     26.83639,

--- a/data/112/586/990/9/1125869909-alt-qs_pg.geojson
+++ b/data/112/586/990/9/1125869909-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"5ca1a6e8a83ce099037d6f1d0e207899",
     "wof:id":1125869909
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     25.89917,

--- a/data/112/586/994/3/1125869943-alt-qs_pg.geojson
+++ b/data/112/586/994/3/1125869943-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"73b04aabfc8f38a919b8a376e2cbe7ef",
     "wof:id":1125869943
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     27.07333,

--- a/data/112/587/115/9/1125871159-alt-qs_pg.geojson
+++ b/data/112/587/115/9/1125871159-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"33cd9e1422e36f0bd42ffdf1d33f6acd",
     "wof:id":1125871159
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     27.5025,

--- a/data/112/587/145/5/1125871455-alt-qs_pg.geojson
+++ b/data/112/587/145/5/1125871455-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"548b3a91472289de9df3704f98d3c813",
     "wof:id":1125871455
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     23.90333,

--- a/data/112/587/244/9/1125872449-alt-qs_pg.geojson
+++ b/data/112/587/244/9/1125872449-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"eca1a988a06495ad5eae9f1c0b54e70e",
     "wof:id":1125872449
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     27.29361,

--- a/data/112/588/293/7/1125882937-alt-qs_pg.geojson
+++ b/data/112/588/293/7/1125882937-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"a405faf72df77b3258420348287b7862",
     "wof:id":1125882937
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     24.82417,

--- a/data/112/588/796/5/1125887965-alt-qs_pg.geojson
+++ b/data/112/588/796/5/1125887965-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"ee928391abbcb28e2ae8f02f7ec43c95",
     "wof:id":1125887965
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     22.69694,

--- a/data/112/588/987/7/1125889877-alt-qs_pg.geojson
+++ b/data/112/588/987/7/1125889877-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"bfd929578ecf647aa3e24e6dc1d9d20b",
     "wof:id":1125889877
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     24.84472,

--- a/data/112/588/988/5/1125889885-alt-qs_pg.geojson
+++ b/data/112/588/988/5/1125889885-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"d277c33c457070b54dcead21acc29be6",
     "wof:id":1125889885
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     22.78972,

--- a/data/112/589/003/5/1125890035-alt-qs_pg.geojson
+++ b/data/112/589/003/5/1125890035-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"91737b19c857e63262a920c640fc2bb6",
     "wof:id":1125890035
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     25.44639,

--- a/data/112/589/022/7/1125890227-alt-qs_pg.geojson
+++ b/data/112/589/022/7/1125890227-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"2254129c7f10a9e6df3b2bb402697f22",
     "wof:id":1125890227
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     24.76083,

--- a/data/112/589/028/1/1125890281-alt-qs_pg.geojson
+++ b/data/112/589/028/1/1125890281-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"04a9350b39916ec837f0e6bb1380137b",
     "wof:id":1125890281
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     27.30806,

--- a/data/112/589/029/1/1125890291-alt-qs_pg.geojson
+++ b/data/112/589/029/1/1125890291-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"df31991256125da18711208fd07df6e9",
     "wof:id":1125890291
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     24.84361,

--- a/data/112/589/031/3/1125890313-alt-qs_pg.geojson
+++ b/data/112/589/031/3/1125890313-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"b2659c139f169509d9a34b2291fec876",
     "wof:id":1125890313
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     25.94583,

--- a/data/112/589/033/9/1125890339-alt-qs_pg.geojson
+++ b/data/112/589/033/9/1125890339-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"4b8c1654ac31db82641f49f6e2716cc0",
     "wof:id":1125890339
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     26.61222,

--- a/data/112/589/038/1/1125890381-alt-qs_pg.geojson
+++ b/data/112/589/038/1/1125890381-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"782e460add2a9512b214acbefbd3c2e9",
     "wof:id":1125890381
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     26.67028,

--- a/data/112/589/038/7/1125890387-alt-qs_pg.geojson
+++ b/data/112/589/038/7/1125890387-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"2743a12691dbdcb8bdefbf70cbb9fbd7",
     "wof:id":1125890387
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     27.03028,

--- a/data/112/589/050/1/1125890501-alt-qs_pg.geojson
+++ b/data/112/589/050/1/1125890501-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"f7d80fd5bbcac92af82b1ee70da6b39d",
     "wof:id":1125890501
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     26.6875,

--- a/data/112/589/052/7/1125890527-alt-qs_pg.geojson
+++ b/data/112/589/052/7/1125890527-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"fc37b57cb2aff38386663ab851c6734c",
     "wof:id":1125890527
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     27.54528,

--- a/data/112/589/262/1/1125892621-alt-qs_pg.geojson
+++ b/data/112/589/262/1/1125892621-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"4c8fce6175545bc69f67054f7fca506b",
     "wof:id":1125892621
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     24.30444,

--- a/data/112/590/822/9/1125908229-alt-qs_pg.geojson
+++ b/data/112/590/822/9/1125908229-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"9a902f8aa81ad17fb023d429abea370e",
     "wof:id":1125908229
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     26.56222,

--- a/data/112/590/848/3/1125908483-alt-qs_pg.geojson
+++ b/data/112/590/848/3/1125908483-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"3542009c321ae7c045ba61226a076dfa",
     "wof:id":1125908483
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     24.29,

--- a/data/112/591/092/9/1125910929-alt-qs_pg.geojson
+++ b/data/112/591/092/9/1125910929-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"3642a65d52de83ddb10814278dbde9f2",
     "wof:id":1125910929
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     22.26222,

--- a/data/112/591/294/3/1125912943-alt-qs_pg.geojson
+++ b/data/112/591/294/3/1125912943-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"7019ae7ef040adf53a0378cf3235eab1",
     "wof:id":1125912943
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     27.13361,

--- a/data/112/592/811/1/1125928111-alt-qs_pg.geojson
+++ b/data/112/592/811/1/1125928111-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"a4c1d5468a0b41ad97d42cd69ddeb203",
     "wof:id":1125928111
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     25.84556,

--- a/data/112/593/229/7/1125932297-alt-qs_pg.geojson
+++ b/data/112/593/229/7/1125932297-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"abd33e181962803f6708559a059d471f",
     "wof:id":1125932297
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     25.97528,

--- a/data/112/593/231/1/1125932311-alt-qs_pg.geojson
+++ b/data/112/593/231/1/1125932311-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"dfd6369a37ed9cd5d37bec3721d54b16",
     "wof:id":1125932311
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     26.92861,

--- a/data/112/593/233/3/1125932333-alt-qs_pg.geojson
+++ b/data/112/593/233/3/1125932333-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"9d2916f9961d9540e5486aaaf7feb8fa",
     "wof:id":1125932333
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     25.42806,

--- a/data/112/593/235/1/1125932351-alt-qs_pg.geojson
+++ b/data/112/593/235/1/1125932351-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"3690ba731fccf86526848358679d0a8c",
     "wof:id":1125932351
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     26.53222,

--- a/data/112/593/411/1/1125934111-alt-qs_pg.geojson
+++ b/data/112/593/411/1/1125934111-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"2f50496f631f3009dd2a4b05efa7f77f",
     "wof:id":1125934111
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     24.90333,

--- a/data/112/593/466/5/1125934665-alt-qs_pg.geojson
+++ b/data/112/593/466/5/1125934665-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"33bd21c8927f0ce35a7ecaf5342487ba",
     "wof:id":1125934665
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     26.56556,

--- a/data/112/593/478/3/1125934783-alt-qs_pg.geojson
+++ b/data/112/593/478/3/1125934783-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"5157c72939d00c9eb10d760ed8058047",
     "wof:id":1125934783
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     27.045,

--- a/data/112/593/555/7/1125935557-alt-qs_pg.geojson
+++ b/data/112/593/555/7/1125935557-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"e07de45dac8b768517ba146980c5eb20",
     "wof:id":1125935557
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     24.805,

--- a/data/112/593/581/3/1125935813-alt-qs_pg.geojson
+++ b/data/112/593/581/3/1125935813-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"c30852a2508cd6caf5188c5630d52b21",
     "wof:id":1125935813
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     26.65056,

--- a/data/112/593/595/3/1125935953-alt-qs_pg.geojson
+++ b/data/112/593/595/3/1125935953-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"2d5de25238ffc7783307baaf6ea86e1d",
     "wof:id":1125935953
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     26.87139,

--- a/data/112/593/606/5/1125936065-alt-qs_pg.geojson
+++ b/data/112/593/606/5/1125936065-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"16cd5d03cd5df0e81f32bd6ad552a6a4",
     "wof:id":1125936065
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     26.15389,

--- a/data/112/593/653/9/1125936539-alt-qs_pg.geojson
+++ b/data/112/593/653/9/1125936539-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"d0a2d85c397c23a86aa81893bc6c11ea",
     "wof:id":1125936539
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     26.73833,

--- a/data/112/593/673/1/1125936731-alt-qs_pg.geojson
+++ b/data/112/593/673/1/1125936731-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"ebc6744e09fbcfed2921c21ae5518373",
     "wof:id":1125936731
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     26.42611,

--- a/data/112/593/823/5/1125938235-alt-qs_pg.geojson
+++ b/data/112/593/823/5/1125938235-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"56718525d0eb7bc24bba67aa56f3b21f",
     "wof:id":1125938235
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     25.53528,

--- a/data/112/593/832/3/1125938323-alt-qs_pg.geojson
+++ b/data/112/593/832/3/1125938323-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"a284c51eb96189aa5ec868925d9a1df9",
     "wof:id":1125938323
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     23.52389,

--- a/data/112/594/141/1/1125941411-alt-qs_pg.geojson
+++ b/data/112/594/141/1/1125941411-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"662ea705c1f163e8463695d8aef93d65",
     "wof:id":1125941411
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     25.89722,

--- a/data/112/594/144/7/1125941447-alt-qs_pg.geojson
+++ b/data/112/594/144/7/1125941447-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"20bd5883e933786dd79a92eb8737dd26",
     "wof:id":1125941447
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     24.38889,

--- a/data/112/595/103/1/1125951031-alt-qs_pg.geojson
+++ b/data/112/595/103/1/1125951031-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"4bcd549b5095cba9ee8965ecfdd672fa",
     "wof:id":1125951031
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     27.01889,

--- a/data/112/595/202/7/1125952027-alt-qs_pg.geojson
+++ b/data/112/595/202/7/1125952027-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"7b567ee896c44bc2ea5dbad8b5820864",
     "wof:id":1125952027
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     25.37944,

--- a/data/112/595/513/3/1125955133-alt-qs_pg.geojson
+++ b/data/112/595/513/3/1125955133-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"b2db38359c72e9e5e0c7c1efeb2454da",
     "wof:id":1125955133
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     26.05833,

--- a/data/112/595/561/9/1125955619-alt-qs_pg.geojson
+++ b/data/112/595/561/9/1125955619-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"e537bf557bd3e536ca1473e398c8bc39",
     "wof:id":1125955619
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     25.31167,

--- a/data/112/595/564/5/1125955645-alt-qs_pg.geojson
+++ b/data/112/595/564/5/1125955645-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"bbba38eb1944d6b9073deacb729f2517",
     "wof:id":1125955645
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     26.25361,

--- a/data/112/595/620/1/1125956201-alt-qs_pg.geojson
+++ b/data/112/595/620/1/1125956201-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"cc49f2afbb5c85b4067b39995c8b8240",
     "wof:id":1125956201
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     27.23778,

--- a/data/112/595/671/1/1125956711-alt-qs_pg.geojson
+++ b/data/112/595/671/1/1125956711-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"c702131fe23c65b14a4d446123d349a0",
     "wof:id":1125956711
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     26.60028,

--- a/data/112/595/673/5/1125956735-alt-qs_pg.geojson
+++ b/data/112/595/673/5/1125956735-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"671e7c23433f62d48af47acfa7622384",
     "wof:id":1125956735
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     26.24806,

--- a/data/112/595/756/7/1125957567-alt-qs_pg.geojson
+++ b/data/112/595/756/7/1125957567-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"c7662b1b5af0217841f05c722c2f692a",
     "wof:id":1125957567
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     27.35194,

--- a/data/112/596/181/9/1125961819-alt-qs_pg.geojson
+++ b/data/112/596/181/9/1125961819-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"9fd88f60c07c54ed5b9208ddfb5988ec",
     "wof:id":1125961819
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     26.5225,

--- a/data/112/596/291/3/1125962913-alt-qs_pg.geojson
+++ b/data/112/596/291/3/1125962913-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"3bde7999fd0d3d0f427701f15e982d26",
     "wof:id":1125962913
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     25.04417,

--- a/data/112/596/847/3/1125968473-alt-qs_pg.geojson
+++ b/data/112/596/847/3/1125968473-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"3263240af69b73753dffbfe24d06c732",
     "wof:id":1125968473
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     24.96583,

--- a/data/112/597/156/5/1125971565-alt-qs_pg.geojson
+++ b/data/112/597/156/5/1125971565-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"2d3519b4d07d547a784eac22fb47300f",
     "wof:id":1125971565
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     25.565,

--- a/data/112/597/162/7/1125971627-alt-qs_pg.geojson
+++ b/data/112/597/162/7/1125971627-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"058eb1b54448badb4e7b86756a83e892",
     "wof:id":1125971627
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     26.98306,

--- a/data/112/597/171/5/1125971715-alt-qs_pg.geojson
+++ b/data/112/597/171/5/1125971715-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"3dc652f9fba92dc323dd22dfdef340d6",
     "wof:id":1125971715
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     26.70917,

--- a/data/112/598/416/7/1125984167-alt-qs_pg.geojson
+++ b/data/112/598/416/7/1125984167-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"23b9930fd65b7d0d4f358c3d07dd3cf8",
     "wof:id":1125984167
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     25.37083,

--- a/data/112/600/358/3/1126003583-alt-qs_pg.geojson
+++ b/data/112/600/358/3/1126003583-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"00872e1780691541105d698a1c760863",
     "wof:id":1126003583
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     24.6525,

--- a/data/112/600/359/1/1126003591-alt-qs_pg.geojson
+++ b/data/112/600/359/1/1126003591-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"35a7fde9586a92a8ceaddce2c0656ead",
     "wof:id":1126003591
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     24.81833,

--- a/data/112/600/362/1/1126003621-alt-qs_pg.geojson
+++ b/data/112/600/362/1/1126003621-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"2a3fa92d3b6b2bb406f4ba19ae032519",
     "wof:id":1126003621
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     22.25972,

--- a/data/112/600/374/7/1126003747-alt-qs_pg.geojson
+++ b/data/112/600/374/7/1126003747-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"f55327b4f553ac960f0101b89ba02b00",
     "wof:id":1126003747
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     27.215,

--- a/data/112/600/381/7/1126003817-alt-qs_pg.geojson
+++ b/data/112/600/381/7/1126003817-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"a0f543bcd76ff111d5694637a98000ea",
     "wof:id":1126003817
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     24.94222,

--- a/data/112/600/388/3/1126003883-alt-qs_pg.geojson
+++ b/data/112/600/388/3/1126003883-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"8dee4765d16f0237f8d7a8522bec307c",
     "wof:id":1126003883
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     26.57889,

--- a/data/112/600/395/3/1126003953-alt-qs_pg.geojson
+++ b/data/112/600/395/3/1126003953-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"3f3ae09f8ddffa42668a914194cdf659",
     "wof:id":1126003953
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     26.19694,

--- a/data/112/600/396/1/1126003961-alt-qs_pg.geojson
+++ b/data/112/600/396/1/1126003961-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"5acf16317f57e3d1be32eb465973214c",
     "wof:id":1126003961
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     26.85806,

--- a/data/112/600/830/1/1126008301-alt-qs_pg.geojson
+++ b/data/112/600/830/1/1126008301-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"74736234333b29a864f047a0ec1992fe",
     "wof:id":1126008301
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     26.64417,

--- a/data/112/600/830/7/1126008307-alt-qs_pg.geojson
+++ b/data/112/600/830/7/1126008307-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"f5502a239b18792a8257cbbff1716dab",
     "wof:id":1126008307
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     22.45889,

--- a/data/112/600/833/1/1126008331-alt-qs_pg.geojson
+++ b/data/112/600/833/1/1126008331-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"292dfb08bafaf049773242feb35db2fd",
     "wof:id":1126008331
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     26.75639,

--- a/data/112/600/834/7/1126008347-alt-qs_pg.geojson
+++ b/data/112/600/834/7/1126008347-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"e0faef03e4fef0047e997843a57bf420",
     "wof:id":1126008347
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     25.14806,

--- a/data/112/600/840/1/1126008401-alt-qs_pg.geojson
+++ b/data/112/600/840/1/1126008401-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"1686eac0361fb5b321c9413bea13c9c1",
     "wof:id":1126008401
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     26.78222,

--- a/data/112/600/840/9/1126008409-alt-qs_pg.geojson
+++ b/data/112/600/840/9/1126008409-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"ba11405e7988a5c5c38dd6163e7d9df5",
     "wof:id":1126008409
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     27.03694,

--- a/data/112/600/848/7/1126008487-alt-qs_pg.geojson
+++ b/data/112/600/848/7/1126008487-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"ae3c89c5cc0c9f76e051e70247384fb8",
     "wof:id":1126008487
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     27.4725,

--- a/data/112/600/850/3/1126008503-alt-qs_pg.geojson
+++ b/data/112/600/850/3/1126008503-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"77a7169474fb4e9a9ac5d7eef518ca57",
     "wof:id":1126008503
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     27.19278,

--- a/data/112/600/859/9/1126008599-alt-qs_pg.geojson
+++ b/data/112/600/859/9/1126008599-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"d7256e73b2136adbc174733658bb741c",
     "wof:id":1126008599
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     25.21639,

--- a/data/112/600/873/9/1126008739-alt-qs_pg.geojson
+++ b/data/112/600/873/9/1126008739-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"cb3789b9e442cde76f10137c0e0b6a11",
     "wof:id":1126008739
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     27.04806,

--- a/data/112/601/766/7/1126017667-alt-qs_pg.geojson
+++ b/data/112/601/766/7/1126017667-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"2b0cdb25618d8b8e3a42339706b98d5b",
     "wof:id":1126017667
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     24.71861,

--- a/data/112/601/768/5/1126017685-alt-qs_pg.geojson
+++ b/data/112/601/768/5/1126017685-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"48e1aebc16cca7a0fac05d5429e2a8f2",
     "wof:id":1126017685
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     26.88083,

--- a/data/112/601/770/3/1126017703-alt-qs_pg.geojson
+++ b/data/112/601/770/3/1126017703-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"7cf3f994ef3abe4cce8bd9897f6b2fb1",
     "wof:id":1126017703
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     23.52417,

--- a/data/112/601/774/3/1126017743-alt-qs_pg.geojson
+++ b/data/112/601/774/3/1126017743-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"81063cd10b58f39896df541846e64960",
     "wof:id":1126017743
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     26.45861,

--- a/data/112/601/775/3/1126017753-alt-qs_pg.geojson
+++ b/data/112/601/775/3/1126017753-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"7698b07ad623aa75933d7ba5cf172f5b",
     "wof:id":1126017753
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     23.99972,

--- a/data/112/601/780/7/1126017807-alt-qs_pg.geojson
+++ b/data/112/601/780/7/1126017807-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"baf60371f212b144b0d14ddac607b218",
     "wof:id":1126017807
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     27.23583,

--- a/data/112/601/884/1/1126018841-alt-qs_pg.geojson
+++ b/data/112/601/884/1/1126018841-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"51e8ddb587cc527efb39516f96059463",
     "wof:id":1126018841
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     26.21417,

--- a/data/112/601/955/7/1126019557-alt-qs_pg.geojson
+++ b/data/112/601/955/7/1126019557-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"8b062d574df88586556ad89d0ade1c72",
     "wof:id":1126019557
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     24.94278,

--- a/data/112/602/050/7/1126020507-alt-qs_pg.geojson
+++ b/data/112/602/050/7/1126020507-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"ca7682fcef14ef103be0c366c03562f8",
     "wof:id":1126020507
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     25.83333,

--- a/data/112/603/183/7/1126031837-alt-qs_pg.geojson
+++ b/data/112/603/183/7/1126031837-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"867145edfb160eccc179559ee1526812",
     "wof:id":1126031837
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     26.86417,

--- a/data/112/603/203/3/1126032033-alt-qs_pg.geojson
+++ b/data/112/603/203/3/1126032033-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"487aead22a529549d563a44f4645d70e",
     "wof:id":1126032033
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     24.38556,

--- a/data/112/603/206/7/1126032067-alt-qs_pg.geojson
+++ b/data/112/603/206/7/1126032067-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"2ddd2ea829ade88cf00213ce47e549d5",
     "wof:id":1126032067
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     22.04694,

--- a/data/112/603/208/9/1126032089-alt-qs_pg.geojson
+++ b/data/112/603/208/9/1126032089-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"f28c19a07938dc0c5c1d5750a7a1e140",
     "wof:id":1126032089
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     26.46389,

--- a/data/112/603/218/9/1126032189-alt-qs_pg.geojson
+++ b/data/112/603/218/9/1126032189-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"72d2b8b49b45d80c2fe0207cd5d947c8",
     "wof:id":1126032189
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     22.54917,

--- a/data/112/603/250/3/1126032503-alt-qs_pg.geojson
+++ b/data/112/603/250/3/1126032503-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"86f1846dc213af84b2601cea63a0e923",
     "wof:id":1126032503
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     25.56278,

--- a/data/112/603/268/1/1126032681-alt-qs_pg.geojson
+++ b/data/112/603/268/1/1126032681-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"8174cf2460f6e05dd7ed3da665feabde",
     "wof:id":1126032681
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     23.75222,

--- a/data/112/603/743/7/1126037437-alt-qs_pg.geojson
+++ b/data/112/603/743/7/1126037437-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"9112e7ab1a7d844747afeda98fab08dc",
     "wof:id":1126037437
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     26.99,

--- a/data/112/603/752/5/1126037525-alt-qs_pg.geojson
+++ b/data/112/603/752/5/1126037525-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"e2f016330449b807fdded2cffb658a44",
     "wof:id":1126037525
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     26.0,

--- a/data/112/603/756/3/1126037563-alt-qs_pg.geojson
+++ b/data/112/603/756/3/1126037563-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"54bd17705eec40312e695cfa68f19806",
     "wof:id":1126037563
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     27.23,

--- a/data/112/603/771/3/1126037713-alt-qs_pg.geojson
+++ b/data/112/603/771/3/1126037713-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"ce94f14f8730fc8ffaf015ddc459b65c",
     "wof:id":1126037713
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     26.4025,

--- a/data/112/603/773/7/1126037737-alt-qs_pg.geojson
+++ b/data/112/603/773/7/1126037737-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"4db9f092a326e07e8b64c500a40ae266",
     "wof:id":1126037737
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     26.17889,

--- a/data/112/603/778/9/1126037789-alt-qs_pg.geojson
+++ b/data/112/603/778/9/1126037789-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"6f6d14b3be1b7aa14f75ece1e53cc796",
     "wof:id":1126037789
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     26.27528,

--- a/data/112/603/780/9/1126037809-alt-qs_pg.geojson
+++ b/data/112/603/780/9/1126037809-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"f912fbb6ed863947341c3cab75cef0a0",
     "wof:id":1126037809
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     26.21806,

--- a/data/112/603/782/9/1126037829-alt-qs_pg.geojson
+++ b/data/112/603/782/9/1126037829-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"0d5353cb59d7939b6e91a410f5d5dc65",
     "wof:id":1126037829
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     26.33944,

--- a/data/112/603/784/3/1126037843-alt-qs_pg.geojson
+++ b/data/112/603/784/3/1126037843-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"e068131e09204d5e78e7e772a9fd6eea",
     "wof:id":1126037843
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     26.82528,

--- a/data/112/603/795/1/1126037951-alt-qs_pg.geojson
+++ b/data/112/603/795/1/1126037951-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"e013fedb03317ed3fa99d20ba6b6d2dd",
     "wof:id":1126037951
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     26.73111,

--- a/data/112/603/901/9/1126039019-alt-qs_pg.geojson
+++ b/data/112/603/901/9/1126039019-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"bc4de9be7652234057095084c3d52838",
     "wof:id":1126039019
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     25.75417,

--- a/data/112/603/907/9/1126039079-alt-qs_pg.geojson
+++ b/data/112/603/907/9/1126039079-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"df3bb78e979ee6e1389e6706d69469ad",
     "wof:id":1126039079
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     26.22639,

--- a/data/112/603/908/3/1126039083-alt-qs_pg.geojson
+++ b/data/112/603/908/3/1126039083-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"01443d1e3d9eba69d920880521a13930",
     "wof:id":1126039083
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     26.315,

--- a/data/112/603/909/3/1126039093-alt-qs_pg.geojson
+++ b/data/112/603/909/3/1126039093-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"c0391293025b3bf77dd833bc01a4a8c5",
     "wof:id":1126039093
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     26.47583,

--- a/data/112/604/513/3/1126045133-alt-qs_pg.geojson
+++ b/data/112/604/513/3/1126045133-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"361b5364fb1430a5d48e15529649ce27",
     "wof:id":1126045133
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     22.385,

--- a/data/112/605/697/1/1126056971-alt-qs_pg.geojson
+++ b/data/112/605/697/1/1126056971-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"27ca7dae0ed32ccfe4216bfd60799965",
     "wof:id":1126056971
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     24.65861,

--- a/data/112/605/697/3/1126056973-alt-qs_pg.geojson
+++ b/data/112/605/697/3/1126056973-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"39761588f3d8a200ebaa409e288bc1ea",
     "wof:id":1126056973
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     24.49719,

--- a/data/112/605/699/3/1126056993-alt-qs_pg.geojson
+++ b/data/112/605/699/3/1126056993-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"5f1cc3efc197566b436f6b147313c8b9",
     "wof:id":1126056993
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     25.17528,

--- a/data/112/605/701/7/1126057017-alt-qs_pg.geojson
+++ b/data/112/605/701/7/1126057017-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"81cc51c5cf4bad8e386004216f459a49",
     "wof:id":1126057017
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     26.41139,

--- a/data/112/605/705/3/1126057053-alt-qs_pg.geojson
+++ b/data/112/605/705/3/1126057053-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"4f813aa23527b41e220683d0b274fba8",
     "wof:id":1126057053
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     26.17333,

--- a/data/112/605/716/3/1126057163-alt-qs_pg.geojson
+++ b/data/112/605/716/3/1126057163-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"5464bc0591a761d30d039433adc311bc",
     "wof:id":1126057163
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     25.55028,

--- a/data/112/605/722/7/1126057227-alt-qs_pg.geojson
+++ b/data/112/605/722/7/1126057227-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"45aec2237d0b552ce7898b6ae6a66298",
     "wof:id":1126057227
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     26.40389,

--- a/data/112/605/727/9/1126057279-alt-qs_pg.geojson
+++ b/data/112/605/727/9/1126057279-alt-qs_pg.geojson
@@ -5,6 +5,8 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"b770c5fa8beba08aaca00bcfd56bdc14",
     "wof:id":1126057279
+    "wof:repo":"whosonfirst-data-admin-ee,
+    "src:alt_label":"qs_pg"
 },
   "bbox": [
     22.80111,

--- a/data/119/302/560/7/1193025607-alt-geonames.geojson
+++ b/data/119/302/560/7/1193025607-alt-geonames.geojson
@@ -2,9 +2,11 @@
   "id": 1193025607,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"geonames",
     "src:geom":"geonames",
     "wof:geomhash":"e49825f8e727bd734e719e9d57a7e32d",
-    "wof:id":1193025607
+    "wof:id":1193025607,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     24.77702,

--- a/data/120/962/480/1/1209624801-alt-geonames.geojson
+++ b/data/120/962/480/1/1209624801-alt-geonames.geojson
@@ -2,9 +2,11 @@
   "id": 1209624801,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"geonames",
     "src:geom":"geonames",
     "wof:geomhash":"c50c3db14d55db811110e693f04bd059",
-    "wof:id":1209624801
+    "wof:id":1209624801,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     24.57176,

--- a/data/122/662/555/5/1226625555-alt-geonames.geojson
+++ b/data/122/662/555/5/1226625555-alt-geonames.geojson
@@ -2,9 +2,11 @@
   "id": 1226625555,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"geonames",
     "src:geom":"geonames",
     "wof:geomhash":"7c8c389fc92a29ed0dc9f0905d6681a1",
-    "wof:id":1226625555
+    "wof:id":1226625555,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     24.97778,

--- a/data/124/337/297/3/1243372973-alt-geonames.geojson
+++ b/data/124/337/297/3/1243372973-alt-geonames.geojson
@@ -2,9 +2,11 @@
   "id": 1243372973,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"geonames",
     "src:geom":"geonames",
     "wof:geomhash":"64e025895daf1867dc0b216b254e9af1",
-    "wof:id":1243372973
+    "wof:id":1243372973,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     24.22139,

--- a/data/124/337/776/3/1243377763-alt-geonames.geojson
+++ b/data/124/337/776/3/1243377763-alt-geonames.geojson
@@ -2,9 +2,11 @@
   "id": 1243377763,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"geonames",
     "src:geom":"geonames",
     "wof:geomhash":"02ab8731dca7e53c46ce3196dd9f2d9c",
-    "wof:id":1243377763
+    "wof:id":1243377763,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     25.61917,

--- a/data/127/653/461/5/1276534615-alt-geonames.geojson
+++ b/data/127/653/461/5/1276534615-alt-geonames.geojson
@@ -2,9 +2,11 @@
   "id": 1276534615,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"geonames",
     "src:geom":"geonames",
     "wof:geomhash":"7db12bbe4e97b37476484d653578d9ea",
-    "wof:id":1276534615
+    "wof:id":1276534615,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     25.05972,

--- a/data/127/703/669/9/1277036699-alt-geonames.geojson
+++ b/data/127/703/669/9/1277036699-alt-geonames.geojson
@@ -2,9 +2,11 @@
   "id": 1277036699,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"geonames",
     "src:geom":"geonames",
     "wof:geomhash":"b71d31080fca23e433512bdc78c7450e",
-    "wof:id":1277036699
+    "wof:id":1277036699,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     25.43333,

--- a/data/127/709/618/7/1277096187-alt-geonames.geojson
+++ b/data/127/709/618/7/1277096187-alt-geonames.geojson
@@ -2,9 +2,11 @@
   "id": 1277096187,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"geonames",
     "src:geom":"geonames",
     "wof:geomhash":"af5e606035eb69d6c0cd75d2690d4354",
-    "wof:id":1277096187
+    "wof:id":1277096187,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     26.3,

--- a/data/129/298/900/1/1292989001-alt-geonames.geojson
+++ b/data/129/298/900/1/1292989001-alt-geonames.geojson
@@ -2,9 +2,11 @@
   "id": 1292989001,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"geonames",
     "src:geom":"geonames",
     "wof:geomhash":"18d70dd72c6a2db6c87585337a1eccf5",
-    "wof:id":1292989001
+    "wof:id":1292989001,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     24.56165,

--- a/data/129/359/782/1/1293597821-alt-geonames.geojson
+++ b/data/129/359/782/1/1293597821-alt-geonames.geojson
@@ -2,9 +2,11 @@
   "id": 1293597821,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"geonames",
     "src:geom":"geonames",
     "wof:geomhash":"ec55125c6ff4f823045fd12ac389eb4d",
-    "wof:id":1293597821
+    "wof:id":1293597821,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     22.46781,

--- a/data/129/365/548/9/1293655489-alt-geonames.geojson
+++ b/data/129/365/548/9/1293655489-alt-geonames.geojson
@@ -2,9 +2,11 @@
   "id": 1293655489,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"geonames",
     "src:geom":"geonames",
     "wof:geomhash":"85553e77fdef015d61e9a3a95063deab",
-    "wof:id":1293655489
+    "wof:id":1293655489,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     26.70056,

--- a/data/136/007/338/1/1360073381-alt-geonames.geojson
+++ b/data/136/007/338/1/1360073381-alt-geonames.geojson
@@ -2,9 +2,11 @@
   "id": 1360073381,
   "type": "Feature",
   "properties": {
+    "src:alt_label":"geonames",
     "src:geom":"geonames",
     "wof:geomhash":"e252f664cdbb9041d9cb8429e6613f40",
-    "wof:id":1360073381
+    "wof:id":1360073381,
+    "wof:repo":"whosonfirst-data-admin-ee"
 },
   "bbox": [
     24.48256,


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1890.

Through #11, I updated admin records in this repo but I did not include `"wof:repo"` or `"src:alt_label"` properties in some alt files. This PR corrects this, adding the properties to all alt files.

No PIP work needed.