### PR TITLE
Fix JSON formatting errors

### DIFF
--- a/data/112/576/534/5/1125765345-alt-qs_pg.geojson
+++ b/data/112/576/534/5/1125765345-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"868805b09a900fd3b3447e69bf640f01",
-    "wof:id":1125765345
+    "wof:id":1125765345,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/576/534/5/1125765345-alt-qs_pg.geojson
+++ b/data/112/576/534/5/1125765345-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"868805b09a900fd3b3447e69bf640f01",
     "wof:id":1125765345,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/576/745/9/1125767459-alt-qs_pg.geojson
+++ b/data/112/576/745/9/1125767459-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"6076859f122b0c600f78a3bc2c6af45c",
     "wof:id":1125767459,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/576/745/9/1125767459-alt-qs_pg.geojson
+++ b/data/112/576/745/9/1125767459-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"6076859f122b0c600f78a3bc2c6af45c",
-    "wof:id":1125767459
+    "wof:id":1125767459,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/580/080/3/1125800803-alt-qs_pg.geojson
+++ b/data/112/580/080/3/1125800803-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"8daefb179081a1da570533e914236062",
-    "wof:id":1125800803
+    "wof:id":1125800803,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/580/080/3/1125800803-alt-qs_pg.geojson
+++ b/data/112/580/080/3/1125800803-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"8daefb179081a1da570533e914236062",
     "wof:id":1125800803,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/580/923/9/1125809239-alt-qs_pg.geojson
+++ b/data/112/580/923/9/1125809239-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"4a326e1603f9eaeefff7214ae65474f9",
-    "wof:id":1125809239
+    "wof:id":1125809239,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/580/923/9/1125809239-alt-qs_pg.geojson
+++ b/data/112/580/923/9/1125809239-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"4a326e1603f9eaeefff7214ae65474f9",
     "wof:id":1125809239,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/581/705/3/1125817053-alt-qs_pg.geojson
+++ b/data/112/581/705/3/1125817053-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"d669ea0ab4690caf20aec4d088d266ce",
     "wof:id":1125817053,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/581/705/3/1125817053-alt-qs_pg.geojson
+++ b/data/112/581/705/3/1125817053-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"d669ea0ab4690caf20aec4d088d266ce",
-    "wof:id":1125817053
+    "wof:id":1125817053,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/581/706/1/1125817061-alt-qs_pg.geojson
+++ b/data/112/581/706/1/1125817061-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"bcf53cb1a7962226507863e0209870c7",
     "wof:id":1125817061,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/581/706/1/1125817061-alt-qs_pg.geojson
+++ b/data/112/581/706/1/1125817061-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"bcf53cb1a7962226507863e0209870c7",
-    "wof:id":1125817061
+    "wof:id":1125817061,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/583/103/9/1125831039-alt-qs_pg.geojson
+++ b/data/112/583/103/9/1125831039-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"88d84e1bafa3efcc91b25802b5c20f7f",
     "wof:id":1125831039,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/583/103/9/1125831039-alt-qs_pg.geojson
+++ b/data/112/583/103/9/1125831039-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"88d84e1bafa3efcc91b25802b5c20f7f",
-    "wof:id":1125831039
+    "wof:id":1125831039,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/583/584/9/1125835849-alt-qs_pg.geojson
+++ b/data/112/583/584/9/1125835849-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"a21a4dc6be0c7511db9cdf2a0ba5cb29",
-    "wof:id":1125835849
+    "wof:id":1125835849,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/583/584/9/1125835849-alt-qs_pg.geojson
+++ b/data/112/583/584/9/1125835849-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"a21a4dc6be0c7511db9cdf2a0ba5cb29",
     "wof:id":1125835849,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/583/589/7/1125835897-alt-qs_pg.geojson
+++ b/data/112/583/589/7/1125835897-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"b8669d7c52e8681558b7d8a0e2f47592",
-    "wof:id":1125835897
+    "wof:id":1125835897,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/583/589/7/1125835897-alt-qs_pg.geojson
+++ b/data/112/583/589/7/1125835897-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"b8669d7c52e8681558b7d8a0e2f47592",
     "wof:id":1125835897,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/583/970/1/1125839701-alt-qs_pg.geojson
+++ b/data/112/583/970/1/1125839701-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"ffa4702595a7fce67d22d54a733a028a",
     "wof:id":1125839701,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/583/970/1/1125839701-alt-qs_pg.geojson
+++ b/data/112/583/970/1/1125839701-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"ffa4702595a7fce67d22d54a733a028a",
-    "wof:id":1125839701
+    "wof:id":1125839701,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/584/037/1/1125840371-alt-qs_pg.geojson
+++ b/data/112/584/037/1/1125840371-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"e99beb637210bfd8a1660cc3473f3c24",
     "wof:id":1125840371,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/584/037/1/1125840371-alt-qs_pg.geojson
+++ b/data/112/584/037/1/1125840371-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"e99beb637210bfd8a1660cc3473f3c24",
-    "wof:id":1125840371
+    "wof:id":1125840371,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/585/036/1/1125850361-alt-qs_pg.geojson
+++ b/data/112/585/036/1/1125850361-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"241ffa0c172d0e178a26022c07d8380d",
     "wof:id":1125850361,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/585/036/1/1125850361-alt-qs_pg.geojson
+++ b/data/112/585/036/1/1125850361-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"241ffa0c172d0e178a26022c07d8380d",
-    "wof:id":1125850361
+    "wof:id":1125850361,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/585/136/9/1125851369-alt-qs_pg.geojson
+++ b/data/112/585/136/9/1125851369-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"554e57f71a4586b5098cc839228b8f79",
-    "wof:id":1125851369
+    "wof:id":1125851369,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/585/136/9/1125851369-alt-qs_pg.geojson
+++ b/data/112/585/136/9/1125851369-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"554e57f71a4586b5098cc839228b8f79",
     "wof:id":1125851369,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/585/481/7/1125854817-alt-qs_pg.geojson
+++ b/data/112/585/481/7/1125854817-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"472b426180bbd4f78154a935cc6fc84d",
-    "wof:id":1125854817
+    "wof:id":1125854817,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/585/481/7/1125854817-alt-qs_pg.geojson
+++ b/data/112/585/481/7/1125854817-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"472b426180bbd4f78154a935cc6fc84d",
     "wof:id":1125854817,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/585/820/1/1125858201-alt-qs_pg.geojson
+++ b/data/112/585/820/1/1125858201-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"3090bafb5918e9025e5924f7ff2a08ab",
     "wof:id":1125858201,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/585/820/1/1125858201-alt-qs_pg.geojson
+++ b/data/112/585/820/1/1125858201-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"3090bafb5918e9025e5924f7ff2a08ab",
-    "wof:id":1125858201
+    "wof:id":1125858201,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/585/823/7/1125858237-alt-qs_pg.geojson
+++ b/data/112/585/823/7/1125858237-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"5f8c6f292cc712804114a17e5b853e30",
     "wof:id":1125858237,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/585/823/7/1125858237-alt-qs_pg.geojson
+++ b/data/112/585/823/7/1125858237-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"5f8c6f292cc712804114a17e5b853e30",
-    "wof:id":1125858237
+    "wof:id":1125858237,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/586/223/7/1125862237-alt-qs_pg.geojson
+++ b/data/112/586/223/7/1125862237-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"3daf9ca734113c7358bd588a342f311f",
     "wof:id":1125862237,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/586/223/7/1125862237-alt-qs_pg.geojson
+++ b/data/112/586/223/7/1125862237-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"3daf9ca734113c7358bd588a342f311f",
-    "wof:id":1125862237
+    "wof:id":1125862237,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/586/686/9/1125866869-alt-qs_pg.geojson
+++ b/data/112/586/686/9/1125866869-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"5795a220ad499fe69d6021b08e1e7e4b",
     "wof:id":1125866869,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/586/686/9/1125866869-alt-qs_pg.geojson
+++ b/data/112/586/686/9/1125866869-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"5795a220ad499fe69d6021b08e1e7e4b",
-    "wof:id":1125866869
+    "wof:id":1125866869,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/586/990/9/1125869909-alt-qs_pg.geojson
+++ b/data/112/586/990/9/1125869909-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"5ca1a6e8a83ce099037d6f1d0e207899",
     "wof:id":1125869909,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/586/990/9/1125869909-alt-qs_pg.geojson
+++ b/data/112/586/990/9/1125869909-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"5ca1a6e8a83ce099037d6f1d0e207899",
-    "wof:id":1125869909
+    "wof:id":1125869909,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/586/994/3/1125869943-alt-qs_pg.geojson
+++ b/data/112/586/994/3/1125869943-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"73b04aabfc8f38a919b8a376e2cbe7ef",
     "wof:id":1125869943,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/586/994/3/1125869943-alt-qs_pg.geojson
+++ b/data/112/586/994/3/1125869943-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"73b04aabfc8f38a919b8a376e2cbe7ef",
-    "wof:id":1125869943
+    "wof:id":1125869943,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/587/115/9/1125871159-alt-qs_pg.geojson
+++ b/data/112/587/115/9/1125871159-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"33cd9e1422e36f0bd42ffdf1d33f6acd",
-    "wof:id":1125871159
+    "wof:id":1125871159,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/587/115/9/1125871159-alt-qs_pg.geojson
+++ b/data/112/587/115/9/1125871159-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"33cd9e1422e36f0bd42ffdf1d33f6acd",
     "wof:id":1125871159,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/587/145/5/1125871455-alt-qs_pg.geojson
+++ b/data/112/587/145/5/1125871455-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"548b3a91472289de9df3704f98d3c813",
-    "wof:id":1125871455
+    "wof:id":1125871455,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/587/145/5/1125871455-alt-qs_pg.geojson
+++ b/data/112/587/145/5/1125871455-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"548b3a91472289de9df3704f98d3c813",
     "wof:id":1125871455,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/587/244/9/1125872449-alt-qs_pg.geojson
+++ b/data/112/587/244/9/1125872449-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"eca1a988a06495ad5eae9f1c0b54e70e",
     "wof:id":1125872449,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/587/244/9/1125872449-alt-qs_pg.geojson
+++ b/data/112/587/244/9/1125872449-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"eca1a988a06495ad5eae9f1c0b54e70e",
-    "wof:id":1125872449
+    "wof:id":1125872449,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/588/293/7/1125882937-alt-qs_pg.geojson
+++ b/data/112/588/293/7/1125882937-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"a405faf72df77b3258420348287b7862",
-    "wof:id":1125882937
+    "wof:id":1125882937,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/588/293/7/1125882937-alt-qs_pg.geojson
+++ b/data/112/588/293/7/1125882937-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"a405faf72df77b3258420348287b7862",
     "wof:id":1125882937,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/588/796/5/1125887965-alt-qs_pg.geojson
+++ b/data/112/588/796/5/1125887965-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"ee928391abbcb28e2ae8f02f7ec43c95",
-    "wof:id":1125887965
+    "wof:id":1125887965,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/588/796/5/1125887965-alt-qs_pg.geojson
+++ b/data/112/588/796/5/1125887965-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"ee928391abbcb28e2ae8f02f7ec43c95",
     "wof:id":1125887965,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/588/987/7/1125889877-alt-qs_pg.geojson
+++ b/data/112/588/987/7/1125889877-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"bfd929578ecf647aa3e24e6dc1d9d20b",
     "wof:id":1125889877,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/588/987/7/1125889877-alt-qs_pg.geojson
+++ b/data/112/588/987/7/1125889877-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"bfd929578ecf647aa3e24e6dc1d9d20b",
-    "wof:id":1125889877
+    "wof:id":1125889877,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/588/988/5/1125889885-alt-qs_pg.geojson
+++ b/data/112/588/988/5/1125889885-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"d277c33c457070b54dcead21acc29be6",
-    "wof:id":1125889885
+    "wof:id":1125889885,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/588/988/5/1125889885-alt-qs_pg.geojson
+++ b/data/112/588/988/5/1125889885-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"d277c33c457070b54dcead21acc29be6",
     "wof:id":1125889885,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/589/003/5/1125890035-alt-qs_pg.geojson
+++ b/data/112/589/003/5/1125890035-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"91737b19c857e63262a920c640fc2bb6",
     "wof:id":1125890035,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/589/003/5/1125890035-alt-qs_pg.geojson
+++ b/data/112/589/003/5/1125890035-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"91737b19c857e63262a920c640fc2bb6",
-    "wof:id":1125890035
+    "wof:id":1125890035,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/589/022/7/1125890227-alt-qs_pg.geojson
+++ b/data/112/589/022/7/1125890227-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"2254129c7f10a9e6df3b2bb402697f22",
     "wof:id":1125890227,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/589/022/7/1125890227-alt-qs_pg.geojson
+++ b/data/112/589/022/7/1125890227-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"2254129c7f10a9e6df3b2bb402697f22",
-    "wof:id":1125890227
+    "wof:id":1125890227,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/589/028/1/1125890281-alt-qs_pg.geojson
+++ b/data/112/589/028/1/1125890281-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"04a9350b39916ec837f0e6bb1380137b",
     "wof:id":1125890281,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/589/028/1/1125890281-alt-qs_pg.geojson
+++ b/data/112/589/028/1/1125890281-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"04a9350b39916ec837f0e6bb1380137b",
-    "wof:id":1125890281
+    "wof:id":1125890281,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/589/029/1/1125890291-alt-qs_pg.geojson
+++ b/data/112/589/029/1/1125890291-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"df31991256125da18711208fd07df6e9",
-    "wof:id":1125890291
+    "wof:id":1125890291,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/589/029/1/1125890291-alt-qs_pg.geojson
+++ b/data/112/589/029/1/1125890291-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"df31991256125da18711208fd07df6e9",
     "wof:id":1125890291,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/589/031/3/1125890313-alt-qs_pg.geojson
+++ b/data/112/589/031/3/1125890313-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"b2659c139f169509d9a34b2291fec876",
     "wof:id":1125890313,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/589/031/3/1125890313-alt-qs_pg.geojson
+++ b/data/112/589/031/3/1125890313-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"b2659c139f169509d9a34b2291fec876",
-    "wof:id":1125890313
+    "wof:id":1125890313,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/589/033/9/1125890339-alt-qs_pg.geojson
+++ b/data/112/589/033/9/1125890339-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"4b8c1654ac31db82641f49f6e2716cc0",
     "wof:id":1125890339,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/589/033/9/1125890339-alt-qs_pg.geojson
+++ b/data/112/589/033/9/1125890339-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"4b8c1654ac31db82641f49f6e2716cc0",
-    "wof:id":1125890339
+    "wof:id":1125890339,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/589/038/1/1125890381-alt-qs_pg.geojson
+++ b/data/112/589/038/1/1125890381-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"782e460add2a9512b214acbefbd3c2e9",
-    "wof:id":1125890381
+    "wof:id":1125890381,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/589/038/1/1125890381-alt-qs_pg.geojson
+++ b/data/112/589/038/1/1125890381-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"782e460add2a9512b214acbefbd3c2e9",
     "wof:id":1125890381,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/589/038/7/1125890387-alt-qs_pg.geojson
+++ b/data/112/589/038/7/1125890387-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"2743a12691dbdcb8bdefbf70cbb9fbd7",
-    "wof:id":1125890387
+    "wof:id":1125890387,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/589/038/7/1125890387-alt-qs_pg.geojson
+++ b/data/112/589/038/7/1125890387-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"2743a12691dbdcb8bdefbf70cbb9fbd7",
     "wof:id":1125890387,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/589/050/1/1125890501-alt-qs_pg.geojson
+++ b/data/112/589/050/1/1125890501-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"f7d80fd5bbcac92af82b1ee70da6b39d",
     "wof:id":1125890501,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/589/050/1/1125890501-alt-qs_pg.geojson
+++ b/data/112/589/050/1/1125890501-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"f7d80fd5bbcac92af82b1ee70da6b39d",
-    "wof:id":1125890501
+    "wof:id":1125890501,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/589/052/7/1125890527-alt-qs_pg.geojson
+++ b/data/112/589/052/7/1125890527-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"fc37b57cb2aff38386663ab851c6734c",
     "wof:id":1125890527,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/589/052/7/1125890527-alt-qs_pg.geojson
+++ b/data/112/589/052/7/1125890527-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"fc37b57cb2aff38386663ab851c6734c",
-    "wof:id":1125890527
+    "wof:id":1125890527,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/589/262/1/1125892621-alt-qs_pg.geojson
+++ b/data/112/589/262/1/1125892621-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"4c8fce6175545bc69f67054f7fca506b",
     "wof:id":1125892621,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/589/262/1/1125892621-alt-qs_pg.geojson
+++ b/data/112/589/262/1/1125892621-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"4c8fce6175545bc69f67054f7fca506b",
-    "wof:id":1125892621
+    "wof:id":1125892621,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/590/822/9/1125908229-alt-qs_pg.geojson
+++ b/data/112/590/822/9/1125908229-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"9a902f8aa81ad17fb023d429abea370e",
     "wof:id":1125908229,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/590/822/9/1125908229-alt-qs_pg.geojson
+++ b/data/112/590/822/9/1125908229-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"9a902f8aa81ad17fb023d429abea370e",
-    "wof:id":1125908229
+    "wof:id":1125908229,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/590/848/3/1125908483-alt-qs_pg.geojson
+++ b/data/112/590/848/3/1125908483-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"3542009c321ae7c045ba61226a076dfa",
-    "wof:id":1125908483
+    "wof:id":1125908483,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/590/848/3/1125908483-alt-qs_pg.geojson
+++ b/data/112/590/848/3/1125908483-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"3542009c321ae7c045ba61226a076dfa",
     "wof:id":1125908483,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/591/092/9/1125910929-alt-qs_pg.geojson
+++ b/data/112/591/092/9/1125910929-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"3642a65d52de83ddb10814278dbde9f2",
-    "wof:id":1125910929
+    "wof:id":1125910929,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/591/092/9/1125910929-alt-qs_pg.geojson
+++ b/data/112/591/092/9/1125910929-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"3642a65d52de83ddb10814278dbde9f2",
     "wof:id":1125910929,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/591/294/3/1125912943-alt-qs_pg.geojson
+++ b/data/112/591/294/3/1125912943-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"7019ae7ef040adf53a0378cf3235eab1",
-    "wof:id":1125912943
+    "wof:id":1125912943,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/591/294/3/1125912943-alt-qs_pg.geojson
+++ b/data/112/591/294/3/1125912943-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"7019ae7ef040adf53a0378cf3235eab1",
     "wof:id":1125912943,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/592/811/1/1125928111-alt-qs_pg.geojson
+++ b/data/112/592/811/1/1125928111-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"a4c1d5468a0b41ad97d42cd69ddeb203",
-    "wof:id":1125928111
+    "wof:id":1125928111,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/592/811/1/1125928111-alt-qs_pg.geojson
+++ b/data/112/592/811/1/1125928111-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"a4c1d5468a0b41ad97d42cd69ddeb203",
     "wof:id":1125928111,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/593/229/7/1125932297-alt-qs_pg.geojson
+++ b/data/112/593/229/7/1125932297-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"abd33e181962803f6708559a059d471f",
     "wof:id":1125932297,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/593/229/7/1125932297-alt-qs_pg.geojson
+++ b/data/112/593/229/7/1125932297-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"abd33e181962803f6708559a059d471f",
-    "wof:id":1125932297
+    "wof:id":1125932297,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/593/231/1/1125932311-alt-qs_pg.geojson
+++ b/data/112/593/231/1/1125932311-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"dfd6369a37ed9cd5d37bec3721d54b16",
     "wof:id":1125932311,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/593/231/1/1125932311-alt-qs_pg.geojson
+++ b/data/112/593/231/1/1125932311-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"dfd6369a37ed9cd5d37bec3721d54b16",
-    "wof:id":1125932311
+    "wof:id":1125932311,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/593/233/3/1125932333-alt-qs_pg.geojson
+++ b/data/112/593/233/3/1125932333-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"9d2916f9961d9540e5486aaaf7feb8fa",
     "wof:id":1125932333,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/593/233/3/1125932333-alt-qs_pg.geojson
+++ b/data/112/593/233/3/1125932333-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"9d2916f9961d9540e5486aaaf7feb8fa",
-    "wof:id":1125932333
+    "wof:id":1125932333,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/593/235/1/1125932351-alt-qs_pg.geojson
+++ b/data/112/593/235/1/1125932351-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"3690ba731fccf86526848358679d0a8c",
     "wof:id":1125932351,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/593/235/1/1125932351-alt-qs_pg.geojson
+++ b/data/112/593/235/1/1125932351-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"3690ba731fccf86526848358679d0a8c",
-    "wof:id":1125932351
+    "wof:id":1125932351,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/593/411/1/1125934111-alt-qs_pg.geojson
+++ b/data/112/593/411/1/1125934111-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"2f50496f631f3009dd2a4b05efa7f77f",
     "wof:id":1125934111,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/593/411/1/1125934111-alt-qs_pg.geojson
+++ b/data/112/593/411/1/1125934111-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"2f50496f631f3009dd2a4b05efa7f77f",
-    "wof:id":1125934111
+    "wof:id":1125934111,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/593/466/5/1125934665-alt-qs_pg.geojson
+++ b/data/112/593/466/5/1125934665-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"33bd21c8927f0ce35a7ecaf5342487ba",
-    "wof:id":1125934665
+    "wof:id":1125934665,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/593/466/5/1125934665-alt-qs_pg.geojson
+++ b/data/112/593/466/5/1125934665-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"33bd21c8927f0ce35a7ecaf5342487ba",
     "wof:id":1125934665,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/593/478/3/1125934783-alt-qs_pg.geojson
+++ b/data/112/593/478/3/1125934783-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"5157c72939d00c9eb10d760ed8058047",
     "wof:id":1125934783,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/593/478/3/1125934783-alt-qs_pg.geojson
+++ b/data/112/593/478/3/1125934783-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"5157c72939d00c9eb10d760ed8058047",
-    "wof:id":1125934783
+    "wof:id":1125934783,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/593/555/7/1125935557-alt-qs_pg.geojson
+++ b/data/112/593/555/7/1125935557-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"e07de45dac8b768517ba146980c5eb20",
     "wof:id":1125935557,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/593/555/7/1125935557-alt-qs_pg.geojson
+++ b/data/112/593/555/7/1125935557-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"e07de45dac8b768517ba146980c5eb20",
-    "wof:id":1125935557
+    "wof:id":1125935557,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/593/581/3/1125935813-alt-qs_pg.geojson
+++ b/data/112/593/581/3/1125935813-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"c30852a2508cd6caf5188c5630d52b21",
-    "wof:id":1125935813
+    "wof:id":1125935813,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/593/581/3/1125935813-alt-qs_pg.geojson
+++ b/data/112/593/581/3/1125935813-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"c30852a2508cd6caf5188c5630d52b21",
     "wof:id":1125935813,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/593/595/3/1125935953-alt-qs_pg.geojson
+++ b/data/112/593/595/3/1125935953-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"2d5de25238ffc7783307baaf6ea86e1d",
-    "wof:id":1125935953
+    "wof:id":1125935953,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/593/595/3/1125935953-alt-qs_pg.geojson
+++ b/data/112/593/595/3/1125935953-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"2d5de25238ffc7783307baaf6ea86e1d",
     "wof:id":1125935953,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/593/606/5/1125936065-alt-qs_pg.geojson
+++ b/data/112/593/606/5/1125936065-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"16cd5d03cd5df0e81f32bd6ad552a6a4",
     "wof:id":1125936065,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/593/606/5/1125936065-alt-qs_pg.geojson
+++ b/data/112/593/606/5/1125936065-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"16cd5d03cd5df0e81f32bd6ad552a6a4",
-    "wof:id":1125936065
+    "wof:id":1125936065,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/593/653/9/1125936539-alt-qs_pg.geojson
+++ b/data/112/593/653/9/1125936539-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"d0a2d85c397c23a86aa81893bc6c11ea",
-    "wof:id":1125936539
+    "wof:id":1125936539,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/593/653/9/1125936539-alt-qs_pg.geojson
+++ b/data/112/593/653/9/1125936539-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"d0a2d85c397c23a86aa81893bc6c11ea",
     "wof:id":1125936539,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/593/673/1/1125936731-alt-qs_pg.geojson
+++ b/data/112/593/673/1/1125936731-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"ebc6744e09fbcfed2921c21ae5518373",
     "wof:id":1125936731,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/593/673/1/1125936731-alt-qs_pg.geojson
+++ b/data/112/593/673/1/1125936731-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"ebc6744e09fbcfed2921c21ae5518373",
-    "wof:id":1125936731
+    "wof:id":1125936731,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/593/823/5/1125938235-alt-qs_pg.geojson
+++ b/data/112/593/823/5/1125938235-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"56718525d0eb7bc24bba67aa56f3b21f",
     "wof:id":1125938235,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/593/823/5/1125938235-alt-qs_pg.geojson
+++ b/data/112/593/823/5/1125938235-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"56718525d0eb7bc24bba67aa56f3b21f",
-    "wof:id":1125938235
+    "wof:id":1125938235,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/593/832/3/1125938323-alt-qs_pg.geojson
+++ b/data/112/593/832/3/1125938323-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"a284c51eb96189aa5ec868925d9a1df9",
     "wof:id":1125938323,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/593/832/3/1125938323-alt-qs_pg.geojson
+++ b/data/112/593/832/3/1125938323-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"a284c51eb96189aa5ec868925d9a1df9",
-    "wof:id":1125938323
+    "wof:id":1125938323,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/594/141/1/1125941411-alt-qs_pg.geojson
+++ b/data/112/594/141/1/1125941411-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"662ea705c1f163e8463695d8aef93d65",
-    "wof:id":1125941411
+    "wof:id":1125941411,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/594/141/1/1125941411-alt-qs_pg.geojson
+++ b/data/112/594/141/1/1125941411-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"662ea705c1f163e8463695d8aef93d65",
     "wof:id":1125941411,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/594/144/7/1125941447-alt-qs_pg.geojson
+++ b/data/112/594/144/7/1125941447-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"20bd5883e933786dd79a92eb8737dd26",
     "wof:id":1125941447,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/594/144/7/1125941447-alt-qs_pg.geojson
+++ b/data/112/594/144/7/1125941447-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"20bd5883e933786dd79a92eb8737dd26",
-    "wof:id":1125941447
+    "wof:id":1125941447,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/595/103/1/1125951031-alt-qs_pg.geojson
+++ b/data/112/595/103/1/1125951031-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"4bcd549b5095cba9ee8965ecfdd672fa",
-    "wof:id":1125951031
+    "wof:id":1125951031,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/595/103/1/1125951031-alt-qs_pg.geojson
+++ b/data/112/595/103/1/1125951031-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"4bcd549b5095cba9ee8965ecfdd672fa",
     "wof:id":1125951031,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/595/202/7/1125952027-alt-qs_pg.geojson
+++ b/data/112/595/202/7/1125952027-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"7b567ee896c44bc2ea5dbad8b5820864",
-    "wof:id":1125952027
+    "wof:id":1125952027,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/595/202/7/1125952027-alt-qs_pg.geojson
+++ b/data/112/595/202/7/1125952027-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"7b567ee896c44bc2ea5dbad8b5820864",
     "wof:id":1125952027,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/595/513/3/1125955133-alt-qs_pg.geojson
+++ b/data/112/595/513/3/1125955133-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"b2db38359c72e9e5e0c7c1efeb2454da",
     "wof:id":1125955133,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/595/513/3/1125955133-alt-qs_pg.geojson
+++ b/data/112/595/513/3/1125955133-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"b2db38359c72e9e5e0c7c1efeb2454da",
-    "wof:id":1125955133
+    "wof:id":1125955133,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/595/561/9/1125955619-alt-qs_pg.geojson
+++ b/data/112/595/561/9/1125955619-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"e537bf557bd3e536ca1473e398c8bc39",
     "wof:id":1125955619,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/595/561/9/1125955619-alt-qs_pg.geojson
+++ b/data/112/595/561/9/1125955619-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"e537bf557bd3e536ca1473e398c8bc39",
-    "wof:id":1125955619
+    "wof:id":1125955619,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/595/564/5/1125955645-alt-qs_pg.geojson
+++ b/data/112/595/564/5/1125955645-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"bbba38eb1944d6b9073deacb729f2517",
-    "wof:id":1125955645
+    "wof:id":1125955645,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/595/564/5/1125955645-alt-qs_pg.geojson
+++ b/data/112/595/564/5/1125955645-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"bbba38eb1944d6b9073deacb729f2517",
     "wof:id":1125955645,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/595/620/1/1125956201-alt-qs_pg.geojson
+++ b/data/112/595/620/1/1125956201-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"cc49f2afbb5c85b4067b39995c8b8240",
     "wof:id":1125956201,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/595/620/1/1125956201-alt-qs_pg.geojson
+++ b/data/112/595/620/1/1125956201-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"cc49f2afbb5c85b4067b39995c8b8240",
-    "wof:id":1125956201
+    "wof:id":1125956201,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/595/671/1/1125956711-alt-qs_pg.geojson
+++ b/data/112/595/671/1/1125956711-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"c702131fe23c65b14a4d446123d349a0",
     "wof:id":1125956711,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/595/671/1/1125956711-alt-qs_pg.geojson
+++ b/data/112/595/671/1/1125956711-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"c702131fe23c65b14a4d446123d349a0",
-    "wof:id":1125956711
+    "wof:id":1125956711,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/595/673/5/1125956735-alt-qs_pg.geojson
+++ b/data/112/595/673/5/1125956735-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"671e7c23433f62d48af47acfa7622384",
     "wof:id":1125956735,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/595/673/5/1125956735-alt-qs_pg.geojson
+++ b/data/112/595/673/5/1125956735-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"671e7c23433f62d48af47acfa7622384",
-    "wof:id":1125956735
+    "wof:id":1125956735,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/595/756/7/1125957567-alt-qs_pg.geojson
+++ b/data/112/595/756/7/1125957567-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"c7662b1b5af0217841f05c722c2f692a",
     "wof:id":1125957567,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/595/756/7/1125957567-alt-qs_pg.geojson
+++ b/data/112/595/756/7/1125957567-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"c7662b1b5af0217841f05c722c2f692a",
-    "wof:id":1125957567
+    "wof:id":1125957567,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/596/181/9/1125961819-alt-qs_pg.geojson
+++ b/data/112/596/181/9/1125961819-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"9fd88f60c07c54ed5b9208ddfb5988ec",
-    "wof:id":1125961819
+    "wof:id":1125961819,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/596/181/9/1125961819-alt-qs_pg.geojson
+++ b/data/112/596/181/9/1125961819-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"9fd88f60c07c54ed5b9208ddfb5988ec",
     "wof:id":1125961819,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/596/291/3/1125962913-alt-qs_pg.geojson
+++ b/data/112/596/291/3/1125962913-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"3bde7999fd0d3d0f427701f15e982d26",
     "wof:id":1125962913,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/596/291/3/1125962913-alt-qs_pg.geojson
+++ b/data/112/596/291/3/1125962913-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"3bde7999fd0d3d0f427701f15e982d26",
-    "wof:id":1125962913
+    "wof:id":1125962913,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/596/847/3/1125968473-alt-qs_pg.geojson
+++ b/data/112/596/847/3/1125968473-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"3263240af69b73753dffbfe24d06c732",
     "wof:id":1125968473,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/596/847/3/1125968473-alt-qs_pg.geojson
+++ b/data/112/596/847/3/1125968473-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"3263240af69b73753dffbfe24d06c732",
-    "wof:id":1125968473
+    "wof:id":1125968473,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/597/156/5/1125971565-alt-qs_pg.geojson
+++ b/data/112/597/156/5/1125971565-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"2d3519b4d07d547a784eac22fb47300f",
     "wof:id":1125971565,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/597/156/5/1125971565-alt-qs_pg.geojson
+++ b/data/112/597/156/5/1125971565-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"2d3519b4d07d547a784eac22fb47300f",
-    "wof:id":1125971565
+    "wof:id":1125971565,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/597/162/7/1125971627-alt-qs_pg.geojson
+++ b/data/112/597/162/7/1125971627-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"058eb1b54448badb4e7b86756a83e892",
     "wof:id":1125971627,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/597/162/7/1125971627-alt-qs_pg.geojson
+++ b/data/112/597/162/7/1125971627-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"058eb1b54448badb4e7b86756a83e892",
-    "wof:id":1125971627
+    "wof:id":1125971627,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/597/171/5/1125971715-alt-qs_pg.geojson
+++ b/data/112/597/171/5/1125971715-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"3dc652f9fba92dc323dd22dfdef340d6",
-    "wof:id":1125971715
+    "wof:id":1125971715,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/597/171/5/1125971715-alt-qs_pg.geojson
+++ b/data/112/597/171/5/1125971715-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"3dc652f9fba92dc323dd22dfdef340d6",
     "wof:id":1125971715,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/598/416/7/1125984167-alt-qs_pg.geojson
+++ b/data/112/598/416/7/1125984167-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"23b9930fd65b7d0d4f358c3d07dd3cf8",
     "wof:id":1125984167,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/598/416/7/1125984167-alt-qs_pg.geojson
+++ b/data/112/598/416/7/1125984167-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"23b9930fd65b7d0d4f358c3d07dd3cf8",
-    "wof:id":1125984167
+    "wof:id":1125984167,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/600/358/3/1126003583-alt-qs_pg.geojson
+++ b/data/112/600/358/3/1126003583-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"00872e1780691541105d698a1c760863",
     "wof:id":1126003583,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/600/358/3/1126003583-alt-qs_pg.geojson
+++ b/data/112/600/358/3/1126003583-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"00872e1780691541105d698a1c760863",
-    "wof:id":1126003583
+    "wof:id":1126003583,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/600/359/1/1126003591-alt-qs_pg.geojson
+++ b/data/112/600/359/1/1126003591-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"35a7fde9586a92a8ceaddce2c0656ead",
     "wof:id":1126003591,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/600/359/1/1126003591-alt-qs_pg.geojson
+++ b/data/112/600/359/1/1126003591-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"35a7fde9586a92a8ceaddce2c0656ead",
-    "wof:id":1126003591
+    "wof:id":1126003591,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/600/362/1/1126003621-alt-qs_pg.geojson
+++ b/data/112/600/362/1/1126003621-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"2a3fa92d3b6b2bb406f4ba19ae032519",
     "wof:id":1126003621,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/600/362/1/1126003621-alt-qs_pg.geojson
+++ b/data/112/600/362/1/1126003621-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"2a3fa92d3b6b2bb406f4ba19ae032519",
-    "wof:id":1126003621
+    "wof:id":1126003621,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/600/374/7/1126003747-alt-qs_pg.geojson
+++ b/data/112/600/374/7/1126003747-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"f55327b4f553ac960f0101b89ba02b00",
-    "wof:id":1126003747
+    "wof:id":1126003747,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/600/374/7/1126003747-alt-qs_pg.geojson
+++ b/data/112/600/374/7/1126003747-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"f55327b4f553ac960f0101b89ba02b00",
     "wof:id":1126003747,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/600/381/7/1126003817-alt-qs_pg.geojson
+++ b/data/112/600/381/7/1126003817-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"a0f543bcd76ff111d5694637a98000ea",
-    "wof:id":1126003817
+    "wof:id":1126003817,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/600/381/7/1126003817-alt-qs_pg.geojson
+++ b/data/112/600/381/7/1126003817-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"a0f543bcd76ff111d5694637a98000ea",
     "wof:id":1126003817,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/600/388/3/1126003883-alt-qs_pg.geojson
+++ b/data/112/600/388/3/1126003883-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"8dee4765d16f0237f8d7a8522bec307c",
     "wof:id":1126003883,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/600/388/3/1126003883-alt-qs_pg.geojson
+++ b/data/112/600/388/3/1126003883-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"8dee4765d16f0237f8d7a8522bec307c",
-    "wof:id":1126003883
+    "wof:id":1126003883,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/600/395/3/1126003953-alt-qs_pg.geojson
+++ b/data/112/600/395/3/1126003953-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"3f3ae09f8ddffa42668a914194cdf659",
-    "wof:id":1126003953
+    "wof:id":1126003953,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/600/395/3/1126003953-alt-qs_pg.geojson
+++ b/data/112/600/395/3/1126003953-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"3f3ae09f8ddffa42668a914194cdf659",
     "wof:id":1126003953,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/600/396/1/1126003961-alt-qs_pg.geojson
+++ b/data/112/600/396/1/1126003961-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"5acf16317f57e3d1be32eb465973214c",
     "wof:id":1126003961,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/600/396/1/1126003961-alt-qs_pg.geojson
+++ b/data/112/600/396/1/1126003961-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"5acf16317f57e3d1be32eb465973214c",
-    "wof:id":1126003961
+    "wof:id":1126003961,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/600/830/1/1126008301-alt-qs_pg.geojson
+++ b/data/112/600/830/1/1126008301-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"74736234333b29a864f047a0ec1992fe",
     "wof:id":1126008301,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/600/830/1/1126008301-alt-qs_pg.geojson
+++ b/data/112/600/830/1/1126008301-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"74736234333b29a864f047a0ec1992fe",
-    "wof:id":1126008301
+    "wof:id":1126008301,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/600/830/7/1126008307-alt-qs_pg.geojson
+++ b/data/112/600/830/7/1126008307-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"f5502a239b18792a8257cbbff1716dab",
     "wof:id":1126008307,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/600/830/7/1126008307-alt-qs_pg.geojson
+++ b/data/112/600/830/7/1126008307-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"f5502a239b18792a8257cbbff1716dab",
-    "wof:id":1126008307
+    "wof:id":1126008307,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/600/833/1/1126008331-alt-qs_pg.geojson
+++ b/data/112/600/833/1/1126008331-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"292dfb08bafaf049773242feb35db2fd",
-    "wof:id":1126008331
+    "wof:id":1126008331,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/600/833/1/1126008331-alt-qs_pg.geojson
+++ b/data/112/600/833/1/1126008331-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"292dfb08bafaf049773242feb35db2fd",
     "wof:id":1126008331,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/600/834/7/1126008347-alt-qs_pg.geojson
+++ b/data/112/600/834/7/1126008347-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"e0faef03e4fef0047e997843a57bf420",
     "wof:id":1126008347,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/600/834/7/1126008347-alt-qs_pg.geojson
+++ b/data/112/600/834/7/1126008347-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"e0faef03e4fef0047e997843a57bf420",
-    "wof:id":1126008347
+    "wof:id":1126008347,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/600/840/1/1126008401-alt-qs_pg.geojson
+++ b/data/112/600/840/1/1126008401-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"1686eac0361fb5b321c9413bea13c9c1",
-    "wof:id":1126008401
+    "wof:id":1126008401,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/600/840/1/1126008401-alt-qs_pg.geojson
+++ b/data/112/600/840/1/1126008401-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"1686eac0361fb5b321c9413bea13c9c1",
     "wof:id":1126008401,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/600/840/9/1126008409-alt-qs_pg.geojson
+++ b/data/112/600/840/9/1126008409-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"ba11405e7988a5c5c38dd6163e7d9df5",
     "wof:id":1126008409,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/600/840/9/1126008409-alt-qs_pg.geojson
+++ b/data/112/600/840/9/1126008409-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"ba11405e7988a5c5c38dd6163e7d9df5",
-    "wof:id":1126008409
+    "wof:id":1126008409,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/600/848/7/1126008487-alt-qs_pg.geojson
+++ b/data/112/600/848/7/1126008487-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"ae3c89c5cc0c9f76e051e70247384fb8",
-    "wof:id":1126008487
+    "wof:id":1126008487,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/600/848/7/1126008487-alt-qs_pg.geojson
+++ b/data/112/600/848/7/1126008487-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"ae3c89c5cc0c9f76e051e70247384fb8",
     "wof:id":1126008487,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/600/850/3/1126008503-alt-qs_pg.geojson
+++ b/data/112/600/850/3/1126008503-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"77a7169474fb4e9a9ac5d7eef518ca57",
     "wof:id":1126008503,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/600/850/3/1126008503-alt-qs_pg.geojson
+++ b/data/112/600/850/3/1126008503-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"77a7169474fb4e9a9ac5d7eef518ca57",
-    "wof:id":1126008503
+    "wof:id":1126008503,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/600/859/9/1126008599-alt-qs_pg.geojson
+++ b/data/112/600/859/9/1126008599-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"d7256e73b2136adbc174733658bb741c",
-    "wof:id":1126008599
+    "wof:id":1126008599,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/600/859/9/1126008599-alt-qs_pg.geojson
+++ b/data/112/600/859/9/1126008599-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"d7256e73b2136adbc174733658bb741c",
     "wof:id":1126008599,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/600/873/9/1126008739-alt-qs_pg.geojson
+++ b/data/112/600/873/9/1126008739-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"cb3789b9e442cde76f10137c0e0b6a11",
     "wof:id":1126008739,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/600/873/9/1126008739-alt-qs_pg.geojson
+++ b/data/112/600/873/9/1126008739-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"cb3789b9e442cde76f10137c0e0b6a11",
-    "wof:id":1126008739
+    "wof:id":1126008739,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/601/766/7/1126017667-alt-qs_pg.geojson
+++ b/data/112/601/766/7/1126017667-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"2b0cdb25618d8b8e3a42339706b98d5b",
     "wof:id":1126017667,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/601/766/7/1126017667-alt-qs_pg.geojson
+++ b/data/112/601/766/7/1126017667-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"2b0cdb25618d8b8e3a42339706b98d5b",
-    "wof:id":1126017667
+    "wof:id":1126017667,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/601/768/5/1126017685-alt-qs_pg.geojson
+++ b/data/112/601/768/5/1126017685-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"48e1aebc16cca7a0fac05d5429e2a8f2",
     "wof:id":1126017685,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/601/768/5/1126017685-alt-qs_pg.geojson
+++ b/data/112/601/768/5/1126017685-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"48e1aebc16cca7a0fac05d5429e2a8f2",
-    "wof:id":1126017685
+    "wof:id":1126017685,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/601/770/3/1126017703-alt-qs_pg.geojson
+++ b/data/112/601/770/3/1126017703-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"7cf3f994ef3abe4cce8bd9897f6b2fb1",
-    "wof:id":1126017703
+    "wof:id":1126017703,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/601/770/3/1126017703-alt-qs_pg.geojson
+++ b/data/112/601/770/3/1126017703-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"7cf3f994ef3abe4cce8bd9897f6b2fb1",
     "wof:id":1126017703,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/601/774/3/1126017743-alt-qs_pg.geojson
+++ b/data/112/601/774/3/1126017743-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"81063cd10b58f39896df541846e64960",
-    "wof:id":1126017743
+    "wof:id":1126017743,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/601/774/3/1126017743-alt-qs_pg.geojson
+++ b/data/112/601/774/3/1126017743-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"81063cd10b58f39896df541846e64960",
     "wof:id":1126017743,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/601/775/3/1126017753-alt-qs_pg.geojson
+++ b/data/112/601/775/3/1126017753-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"7698b07ad623aa75933d7ba5cf172f5b",
     "wof:id":1126017753,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/601/775/3/1126017753-alt-qs_pg.geojson
+++ b/data/112/601/775/3/1126017753-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"7698b07ad623aa75933d7ba5cf172f5b",
-    "wof:id":1126017753
+    "wof:id":1126017753,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/601/780/7/1126017807-alt-qs_pg.geojson
+++ b/data/112/601/780/7/1126017807-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"baf60371f212b144b0d14ddac607b218",
-    "wof:id":1126017807
+    "wof:id":1126017807,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/601/780/7/1126017807-alt-qs_pg.geojson
+++ b/data/112/601/780/7/1126017807-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"baf60371f212b144b0d14ddac607b218",
     "wof:id":1126017807,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/601/884/1/1126018841-alt-qs_pg.geojson
+++ b/data/112/601/884/1/1126018841-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"51e8ddb587cc527efb39516f96059463",
     "wof:id":1126018841,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/601/884/1/1126018841-alt-qs_pg.geojson
+++ b/data/112/601/884/1/1126018841-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"51e8ddb587cc527efb39516f96059463",
-    "wof:id":1126018841
+    "wof:id":1126018841,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/601/955/7/1126019557-alt-qs_pg.geojson
+++ b/data/112/601/955/7/1126019557-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"8b062d574df88586556ad89d0ade1c72",
-    "wof:id":1126019557
+    "wof:id":1126019557,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/601/955/7/1126019557-alt-qs_pg.geojson
+++ b/data/112/601/955/7/1126019557-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"8b062d574df88586556ad89d0ade1c72",
     "wof:id":1126019557,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/602/050/7/1126020507-alt-qs_pg.geojson
+++ b/data/112/602/050/7/1126020507-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"ca7682fcef14ef103be0c366c03562f8",
-    "wof:id":1126020507
+    "wof:id":1126020507,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/602/050/7/1126020507-alt-qs_pg.geojson
+++ b/data/112/602/050/7/1126020507-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"ca7682fcef14ef103be0c366c03562f8",
     "wof:id":1126020507,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/603/183/7/1126031837-alt-qs_pg.geojson
+++ b/data/112/603/183/7/1126031837-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"867145edfb160eccc179559ee1526812",
     "wof:id":1126031837,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/603/183/7/1126031837-alt-qs_pg.geojson
+++ b/data/112/603/183/7/1126031837-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"867145edfb160eccc179559ee1526812",
-    "wof:id":1126031837
+    "wof:id":1126031837,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/603/203/3/1126032033-alt-qs_pg.geojson
+++ b/data/112/603/203/3/1126032033-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"487aead22a529549d563a44f4645d70e",
-    "wof:id":1126032033
+    "wof:id":1126032033,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/603/203/3/1126032033-alt-qs_pg.geojson
+++ b/data/112/603/203/3/1126032033-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"487aead22a529549d563a44f4645d70e",
     "wof:id":1126032033,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/603/206/7/1126032067-alt-qs_pg.geojson
+++ b/data/112/603/206/7/1126032067-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"2ddd2ea829ade88cf00213ce47e549d5",
-    "wof:id":1126032067
+    "wof:id":1126032067,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/603/206/7/1126032067-alt-qs_pg.geojson
+++ b/data/112/603/206/7/1126032067-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"2ddd2ea829ade88cf00213ce47e549d5",
     "wof:id":1126032067,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/603/208/9/1126032089-alt-qs_pg.geojson
+++ b/data/112/603/208/9/1126032089-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"f28c19a07938dc0c5c1d5750a7a1e140",
     "wof:id":1126032089,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/603/208/9/1126032089-alt-qs_pg.geojson
+++ b/data/112/603/208/9/1126032089-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"f28c19a07938dc0c5c1d5750a7a1e140",
-    "wof:id":1126032089
+    "wof:id":1126032089,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/603/218/9/1126032189-alt-qs_pg.geojson
+++ b/data/112/603/218/9/1126032189-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"72d2b8b49b45d80c2fe0207cd5d947c8",
-    "wof:id":1126032189
+    "wof:id":1126032189,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/603/218/9/1126032189-alt-qs_pg.geojson
+++ b/data/112/603/218/9/1126032189-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"72d2b8b49b45d80c2fe0207cd5d947c8",
     "wof:id":1126032189,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/603/250/3/1126032503-alt-qs_pg.geojson
+++ b/data/112/603/250/3/1126032503-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"86f1846dc213af84b2601cea63a0e923",
     "wof:id":1126032503,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/603/250/3/1126032503-alt-qs_pg.geojson
+++ b/data/112/603/250/3/1126032503-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"86f1846dc213af84b2601cea63a0e923",
-    "wof:id":1126032503
+    "wof:id":1126032503,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/603/268/1/1126032681-alt-qs_pg.geojson
+++ b/data/112/603/268/1/1126032681-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"8174cf2460f6e05dd7ed3da665feabde",
     "wof:id":1126032681,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/603/268/1/1126032681-alt-qs_pg.geojson
+++ b/data/112/603/268/1/1126032681-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"8174cf2460f6e05dd7ed3da665feabde",
-    "wof:id":1126032681
+    "wof:id":1126032681,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/603/743/7/1126037437-alt-qs_pg.geojson
+++ b/data/112/603/743/7/1126037437-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"9112e7ab1a7d844747afeda98fab08dc",
-    "wof:id":1126037437
+    "wof:id":1126037437,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/603/743/7/1126037437-alt-qs_pg.geojson
+++ b/data/112/603/743/7/1126037437-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"9112e7ab1a7d844747afeda98fab08dc",
     "wof:id":1126037437,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/603/752/5/1126037525-alt-qs_pg.geojson
+++ b/data/112/603/752/5/1126037525-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"e2f016330449b807fdded2cffb658a44",
     "wof:id":1126037525,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/603/752/5/1126037525-alt-qs_pg.geojson
+++ b/data/112/603/752/5/1126037525-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"e2f016330449b807fdded2cffb658a44",
-    "wof:id":1126037525
+    "wof:id":1126037525,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/603/756/3/1126037563-alt-qs_pg.geojson
+++ b/data/112/603/756/3/1126037563-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"54bd17705eec40312e695cfa68f19806",
-    "wof:id":1126037563
+    "wof:id":1126037563,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/603/756/3/1126037563-alt-qs_pg.geojson
+++ b/data/112/603/756/3/1126037563-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"54bd17705eec40312e695cfa68f19806",
     "wof:id":1126037563,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/603/771/3/1126037713-alt-qs_pg.geojson
+++ b/data/112/603/771/3/1126037713-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"ce94f14f8730fc8ffaf015ddc459b65c",
-    "wof:id":1126037713
+    "wof:id":1126037713,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/603/771/3/1126037713-alt-qs_pg.geojson
+++ b/data/112/603/771/3/1126037713-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"ce94f14f8730fc8ffaf015ddc459b65c",
     "wof:id":1126037713,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/603/773/7/1126037737-alt-qs_pg.geojson
+++ b/data/112/603/773/7/1126037737-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"4db9f092a326e07e8b64c500a40ae266",
     "wof:id":1126037737,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/603/773/7/1126037737-alt-qs_pg.geojson
+++ b/data/112/603/773/7/1126037737-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"4db9f092a326e07e8b64c500a40ae266",
-    "wof:id":1126037737
+    "wof:id":1126037737,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/603/778/9/1126037789-alt-qs_pg.geojson
+++ b/data/112/603/778/9/1126037789-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"6f6d14b3be1b7aa14f75ece1e53cc796",
     "wof:id":1126037789,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/603/778/9/1126037789-alt-qs_pg.geojson
+++ b/data/112/603/778/9/1126037789-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"6f6d14b3be1b7aa14f75ece1e53cc796",
-    "wof:id":1126037789
+    "wof:id":1126037789,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/603/780/9/1126037809-alt-qs_pg.geojson
+++ b/data/112/603/780/9/1126037809-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"f912fbb6ed863947341c3cab75cef0a0",
-    "wof:id":1126037809
+    "wof:id":1126037809,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/603/780/9/1126037809-alt-qs_pg.geojson
+++ b/data/112/603/780/9/1126037809-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"f912fbb6ed863947341c3cab75cef0a0",
     "wof:id":1126037809,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/603/782/9/1126037829-alt-qs_pg.geojson
+++ b/data/112/603/782/9/1126037829-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"0d5353cb59d7939b6e91a410f5d5dc65",
     "wof:id":1126037829,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/603/782/9/1126037829-alt-qs_pg.geojson
+++ b/data/112/603/782/9/1126037829-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"0d5353cb59d7939b6e91a410f5d5dc65",
-    "wof:id":1126037829
+    "wof:id":1126037829,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/603/784/3/1126037843-alt-qs_pg.geojson
+++ b/data/112/603/784/3/1126037843-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"e068131e09204d5e78e7e772a9fd6eea",
     "wof:id":1126037843,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/603/784/3/1126037843-alt-qs_pg.geojson
+++ b/data/112/603/784/3/1126037843-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"e068131e09204d5e78e7e772a9fd6eea",
-    "wof:id":1126037843
+    "wof:id":1126037843,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/603/795/1/1126037951-alt-qs_pg.geojson
+++ b/data/112/603/795/1/1126037951-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"e013fedb03317ed3fa99d20ba6b6d2dd",
-    "wof:id":1126037951
+    "wof:id":1126037951,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/603/795/1/1126037951-alt-qs_pg.geojson
+++ b/data/112/603/795/1/1126037951-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"e013fedb03317ed3fa99d20ba6b6d2dd",
     "wof:id":1126037951,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/603/901/9/1126039019-alt-qs_pg.geojson
+++ b/data/112/603/901/9/1126039019-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"bc4de9be7652234057095084c3d52838",
     "wof:id":1126039019,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/603/901/9/1126039019-alt-qs_pg.geojson
+++ b/data/112/603/901/9/1126039019-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"bc4de9be7652234057095084c3d52838",
-    "wof:id":1126039019
+    "wof:id":1126039019,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/603/907/9/1126039079-alt-qs_pg.geojson
+++ b/data/112/603/907/9/1126039079-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"df3bb78e979ee6e1389e6706d69469ad",
-    "wof:id":1126039079
+    "wof:id":1126039079,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/603/907/9/1126039079-alt-qs_pg.geojson
+++ b/data/112/603/907/9/1126039079-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"df3bb78e979ee6e1389e6706d69469ad",
     "wof:id":1126039079,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/603/908/3/1126039083-alt-qs_pg.geojson
+++ b/data/112/603/908/3/1126039083-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"01443d1e3d9eba69d920880521a13930",
-    "wof:id":1126039083
+    "wof:id":1126039083,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/603/908/3/1126039083-alt-qs_pg.geojson
+++ b/data/112/603/908/3/1126039083-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"01443d1e3d9eba69d920880521a13930",
     "wof:id":1126039083,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/603/909/3/1126039093-alt-qs_pg.geojson
+++ b/data/112/603/909/3/1126039093-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"c0391293025b3bf77dd833bc01a4a8c5",
-    "wof:id":1126039093
+    "wof:id":1126039093,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/603/909/3/1126039093-alt-qs_pg.geojson
+++ b/data/112/603/909/3/1126039093-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"c0391293025b3bf77dd833bc01a4a8c5",
     "wof:id":1126039093,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/604/513/3/1126045133-alt-qs_pg.geojson
+++ b/data/112/604/513/3/1126045133-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"361b5364fb1430a5d48e15529649ce27",
     "wof:id":1126045133,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/604/513/3/1126045133-alt-qs_pg.geojson
+++ b/data/112/604/513/3/1126045133-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"361b5364fb1430a5d48e15529649ce27",
-    "wof:id":1126045133
+    "wof:id":1126045133,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/605/697/1/1126056971-alt-qs_pg.geojson
+++ b/data/112/605/697/1/1126056971-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"27ca7dae0ed32ccfe4216bfd60799965",
-    "wof:id":1126056971
+    "wof:id":1126056971,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/605/697/1/1126056971-alt-qs_pg.geojson
+++ b/data/112/605/697/1/1126056971-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"27ca7dae0ed32ccfe4216bfd60799965",
     "wof:id":1126056971,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/605/697/3/1126056973-alt-qs_pg.geojson
+++ b/data/112/605/697/3/1126056973-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"39761588f3d8a200ebaa409e288bc1ea",
     "wof:id":1126056973,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/605/697/3/1126056973-alt-qs_pg.geojson
+++ b/data/112/605/697/3/1126056973-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"39761588f3d8a200ebaa409e288bc1ea",
-    "wof:id":1126056973
+    "wof:id":1126056973,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/605/699/3/1126056993-alt-qs_pg.geojson
+++ b/data/112/605/699/3/1126056993-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"5f1cc3efc197566b436f6b147313c8b9",
-    "wof:id":1126056993
+    "wof:id":1126056993,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/605/699/3/1126056993-alt-qs_pg.geojson
+++ b/data/112/605/699/3/1126056993-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"5f1cc3efc197566b436f6b147313c8b9",
     "wof:id":1126056993,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/605/701/7/1126057017-alt-qs_pg.geojson
+++ b/data/112/605/701/7/1126057017-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"81cc51c5cf4bad8e386004216f459a49",
     "wof:id":1126057017,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/605/701/7/1126057017-alt-qs_pg.geojson
+++ b/data/112/605/701/7/1126057017-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"81cc51c5cf4bad8e386004216f459a49",
-    "wof:id":1126057017
+    "wof:id":1126057017,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/605/705/3/1126057053-alt-qs_pg.geojson
+++ b/data/112/605/705/3/1126057053-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"4f813aa23527b41e220683d0b274fba8",
     "wof:id":1126057053,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/605/705/3/1126057053-alt-qs_pg.geojson
+++ b/data/112/605/705/3/1126057053-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"4f813aa23527b41e220683d0b274fba8",
-    "wof:id":1126057053
+    "wof:id":1126057053,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/605/716/3/1126057163-alt-qs_pg.geojson
+++ b/data/112/605/716/3/1126057163-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"5464bc0591a761d30d039433adc311bc",
     "wof:id":1126057163,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/605/716/3/1126057163-alt-qs_pg.geojson
+++ b/data/112/605/716/3/1126057163-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"5464bc0591a761d30d039433adc311bc",
-    "wof:id":1126057163
+    "wof:id":1126057163,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/605/722/7/1126057227-alt-qs_pg.geojson
+++ b/data/112/605/722/7/1126057227-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"45aec2237d0b552ce7898b6ae6a66298",
     "wof:id":1126057227,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [

--- a/data/112/605/722/7/1126057227-alt-qs_pg.geojson
+++ b/data/112/605/722/7/1126057227-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"45aec2237d0b552ce7898b6ae6a66298",
-    "wof:id":1126057227
+    "wof:id":1126057227,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/605/727/9/1126057279-alt-qs_pg.geojson
+++ b/data/112/605/727/9/1126057279-alt-qs_pg.geojson
@@ -4,7 +4,7 @@
   "properties": {
     "src:geom":"qs_pg",
     "wof:geomhash":"b770c5fa8beba08aaca00bcfd56bdc14",
-    "wof:id":1126057279
+    "wof:id":1126057279,
     "wof:repo":"whosonfirst-data-admin-ee,
     "src:alt_label":"qs_pg"
 },

--- a/data/112/605/727/9/1126057279-alt-qs_pg.geojson
+++ b/data/112/605/727/9/1126057279-alt-qs_pg.geojson
@@ -5,7 +5,7 @@
     "src:geom":"qs_pg",
     "wof:geomhash":"b770c5fa8beba08aaca00bcfd56bdc14",
     "wof:id":1126057279,
-    "wof:repo":"whosonfirst-data-admin-ee,
+    "wof:repo":"whosonfirst-data-admin-ee",
     "src:alt_label":"qs_pg"
 },
   "bbox": [


### PR DESCRIPTION
Fix for https://github.com/whosonfirst-data/whosonfirst-data/issues/1891

method:

```bash
# validate

find data -type f -name '*.geojson' -print0 | 
    while IFS= read -r -d '' filename; do
      if [ "$(cat $filename | jq -r type 2>/dev/null)" != "object" ]; then
        echo "$filename"
      fi
    done
```

```bash
# fix

find data -type f -name '*.geojson' -print0 | 
    while IFS= read -r -d '' filename; do
      if [ "$(cat $filename | jq -r type 2>/dev/null)" != "object" ]; then
        node fix.js "$filename"
      fi
    done
```

```bash
$ cat fix.js
var fs = require('fs')
var path = process.argv[2]
var file = fs.readFileSync(path, 'utf8')

var lines = file.split('\n')
                .map(line => {
                  if (line.includes('wof:id')){
                    if (line.slice(-1) != ','){
                      line += ','
                    }
                  }
                  if (line.includes('wof:repo')){
                    var count = (line.match(/"/g) || []).length
                    if (count != 4){
                      if (line.slice(-1) == ','){
                        line = line.slice(0, -1) + '",'
                      } else {
                        line += '"'
                      }
                    }
                  }
                  return line
                })

//console.log(lines.join('\n'))
fs.writeFileSync(path, lines.join('\n'))
```