### PR TITLE
Flag coterminous places

### DIFF
--- a/data/101/748/153/101748153.geojson
+++ b/data/101/748/153/101748153.geojson
@@ -793,6 +793,9 @@
         "wd:id":"Q1770",
         "wk:page":"Tallinn"
     },
+    "wof:coterminous":[
+        1713305645
+    ],
     "wof:country":"EE",
     "wof:geom_alt":[
         "quattroshapes"
@@ -815,7 +818,7 @@
     "wof:lang_x_spoken":[
         "est"
     ],
-    "wof:lastmodified":1607390877,
+    "wof:lastmodified":1607983943,
     "wof:megacity":0,
     "wof:name":"Tallinn",
     "wof:parent_id":1713305847,

--- a/data/101/748/155/101748155.geojson
+++ b/data/101/748/155/101748155.geojson
@@ -406,11 +406,11 @@
     "wd:population":58375,
     "wd:wordcount":2697,
     "wof:belongsto":[
-        85683059,
         102191581,
-        1713314091,
         85633135,
-        1713305671
+        1713305671,
+        1713314091,
+        85683059
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -424,6 +424,10 @@
     "wof:concordances_alt":{
         "qs_pg:id":1086552
     },
+    "wof:coterminous":[
+        1713305671,
+        1713314091
+    ],
     "wof:country":"EE",
     "wof:geom_alt":[
         "quattroshapes_pg",
@@ -447,7 +451,7 @@
     "wof:lang_x_spoken":[
         "est"
     ],
-    "wof:lastmodified":1596661156,
+    "wof:lastmodified":1607983944,
     "wof:name":"Narva",
     "wof:parent_id":1713314091,
     "wof:placetype":"locality",

--- a/data/101/753/891/101753891.geojson
+++ b/data/101/753/891/101753891.geojson
@@ -221,11 +221,11 @@
     "woe:name_adm1":"Harjumaa",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        85683055,
         102191581,
-        1713313119,
         85633135,
-        1713305647
+        1713305647,
+        1713313119,
+        85683055
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -237,6 +237,10 @@
     "wof:concordances_alt":{
         "qs_pg:id":42592
     },
+    "wof:coterminous":[
+        1713305647,
+        1713313119
+    ],
     "wof:country":"EE",
     "wof:geom_alt":[
         "quattroshapes"
@@ -259,7 +263,7 @@
     "wof:lang_x_spoken":[
         "est"
     ],
-    "wof:lastmodified":1596663488,
+    "wof:lastmodified":1607983941,
     "wof:name":"Maardu",
     "wof:parent_id":1713313119,
     "wof:placetype":"locality",

--- a/data/101/815/089/101815089.geojson
+++ b/data/101/815/089/101815089.geojson
@@ -359,11 +359,11 @@
     "wd:population":17549,
     "wd:wordcount":1810,
     "wof:belongsto":[
-        85682985,
         102191581,
-        1713312917,
         85633135,
-        1713305641
+        1713305641,
+        1713312917,
+        85682985
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -374,6 +374,10 @@
         "wd:id":"Q44840",
         "wk:page":"Viljandi"
     },
+    "wof:coterminous":[
+        1713305641,
+        1713312917
+    ],
     "wof:country":"EE",
     "wof:geom_alt":[
         "quattroshapes_pg",
@@ -397,7 +401,7 @@
     "wof:lang_x_spoken":[
         "est"
     ],
-    "wof:lastmodified":1596663492,
+    "wof:lastmodified":1607983952,
     "wof:name":"Viljandi",
     "wof:parent_id":1713312917,
     "wof:placetype":"locality",

--- a/data/101/815/171/101815171.geojson
+++ b/data/101/815/171/101815171.geojson
@@ -158,11 +158,11 @@
     "src:population":"geonames",
     "wd:wordcount":560,
     "wof:belongsto":[
-        85683055,
         102191581,
-        1713313739,
         85633135,
-        1713305649
+        1713305649,
+        1713313739,
+        85683055
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -172,6 +172,10 @@
         "wd:id":"Q213740",
         "wk:page":"Loksa"
     },
+    "wof:coterminous":[
+        1713305649,
+        1713313739
+    ],
     "wof:country":"EE",
     "wof:geom_alt":[
         "quattroshapes_pg",
@@ -195,7 +199,7 @@
     "wof:lang_x_spoken":[
         "est"
     ],
-    "wof:lastmodified":1596663470,
+    "wof:lastmodified":1607983956,
     "wof:name":"Loksa",
     "wof:parent_id":1713313739,
     "wof:placetype":"locality",

--- a/data/101/815/187/101815187.geojson
+++ b/data/101/815/187/101815187.geojson
@@ -228,11 +228,11 @@
     "woe:name_adm1":"Harjumaa",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        85683055,
         102191581,
-        1713315095,
         85633135,
-        1713305743
+        1713305743,
+        1713315095,
+        85683055
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -243,6 +243,10 @@
         "wd:id":"Q207275",
         "wk:page":"Keila"
     },
+    "wof:coterminous":[
+        1713305743,
+        1713315095
+    ],
     "wof:country":"EE",
     "wof:geom_alt":[
         "quattroshapes"
@@ -265,7 +269,7 @@
     "wof:lang_x_spoken":[
         "est"
     ],
-    "wof:lastmodified":1596663220,
+    "wof:lastmodified":1607983949,
     "wof:name":"Keila",
     "wof:parent_id":1713315095,
     "wof:placetype":"locality",

--- a/data/101/815/211/101815211.geojson
+++ b/data/101/815/211/101815211.geojson
@@ -207,11 +207,11 @@
     "wd:population":13964,
     "wd:wordcount":1246,
     "wof:belongsto":[
-        85683059,
         102191581,
-        1713314929,
         85633135,
-        1713305729
+        1713305729,
+        1713314929,
+        85683059
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -222,6 +222,10 @@
         "wd:id":"Q207748",
         "wk:page":"Sillam\u00e4e"
     },
+    "wof:coterminous":[
+        1713305729,
+        1713314929
+    ],
     "wof:country":"EE",
     "wof:geom_alt":[
         "quattroshapes_pg",
@@ -245,7 +249,7 @@
     "wof:lang_x_spoken":[
         "est"
     ],
-    "wof:lastmodified":1596661510,
+    "wof:lastmodified":1607983948,
     "wof:name":"Sillam\u00e4e",
     "wof:parent_id":1713314929,
     "wof:placetype":"locality",

--- a/data/101/816/257/101816257.geojson
+++ b/data/101/816/257/101816257.geojson
@@ -225,11 +225,11 @@
     "wd:population":12458,
     "wd:wordcount":204,
     "wof:belongsto":[
-        85682937,
         102191581,
-        1713315923,
         85633135,
-        1713305785
+        1713305785,
+        1713315923,
+        85682937
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -240,6 +240,10 @@
         "wd:id":"Q205271",
         "wk:page":"V\u00f5ru"
     },
+    "wof:coterminous":[
+        1713305785,
+        1713315923
+    ],
     "wof:country":"EE",
     "wof:geom_alt":[
         "quattroshapes_pg",
@@ -263,7 +267,7 @@
     "wof:lang_x_spoken":[
         "est"
     ],
-    "wof:lastmodified":1596676917,
+    "wof:lastmodified":1607983941,
     "wof:name":"V\u00f5ru",
     "wof:parent_id":1713315923,
     "wof:placetype":"locality",

--- a/data/101/839/837/101839837.geojson
+++ b/data/101/839/837/101839837.geojson
@@ -237,11 +237,11 @@
     "wd:population":15303,
     "wd:wordcount":934,
     "wof:belongsto":[
-        85683049,
         102191581,
-        1713314069,
         85633135,
-        1713305667
+        1713305667,
+        1713314069,
+        85683049
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -252,6 +252,10 @@
         "wd:id":"Q191889",
         "wk:page":"Rakvere"
     },
+    "wof:coterminous":[
+        1713305667,
+        1713314069
+    ],
     "wof:country":"EE",
     "wof:geom_alt":[
         "quattroshapes_pg",
@@ -275,7 +279,7 @@
     "wof:lang_x_spoken":[
         "est"
     ],
-    "wof:lastmodified":1596661278,
+    "wof:lastmodified":1607983957,
     "wof:name":"Rakvere",
     "wof:parent_id":1713314069,
     "wof:placetype":"locality",

--- a/data/171/330/562/1/1713305621.geojson
+++ b/data/171/330/562/1/1713305621.geojson
@@ -51,6 +51,9 @@
     "wof:concordances":{
         "ee-mamt:okood":689
     },
+    "wof:coterminous":[
+        1713306221
+    ],
     "wof:country":"EE",
     "wof:created":1595451853,
     "wof:geomhash":"657f8e68ef937526ed7d77904dbb458f",
@@ -69,7 +72,7 @@
     "wof:lang_x_spoken":[
         "est"
     ],
-    "wof:lastmodified":1596675027,
+    "wof:lastmodified":1607984737,
     "wof:name":"Ruhnu",
     "wof:parent_id":85682947,
     "wof:placetype":"county",

--- a/data/171/330/564/1/1713305641.geojson
+++ b/data/171/330/564/1/1713305641.geojson
@@ -51,6 +51,10 @@
     "wof:concordances":{
         "ee-mamt:okood":897
     },
+    "wof:coterminous":[
+        101815089,
+        1713312917
+    ],
     "wof:country":"EE",
     "wof:created":1595451871,
     "wof:geomhash":"9d35b2236ec1692ba6b3c6576967dc22",
@@ -69,7 +73,7 @@
     "wof:lang_x_spoken":[
         "est"
     ],
-    "wof:lastmodified":1596663490,
+    "wof:lastmodified":1607984254,
     "wof:name":"Viljandi",
     "wof:parent_id":85682985,
     "wof:placetype":"county",

--- a/data/171/330/564/5/1713305645.geojson
+++ b/data/171/330/564/5/1713305645.geojson
@@ -51,6 +51,9 @@
     "wof:concordances":{
         "ee-mamt:okood":784
     },
+    "wof:coterminous":[
+        101748153
+    ],
     "wof:country":"EE",
     "wof:created":1595451872,
     "wof:geomhash":"66aacb8f8d7790d8287e843cb954304a",
@@ -69,7 +72,7 @@
     "wof:lang_x_spoken":[
         "est"
     ],
-    "wof:lastmodified":1596663503,
+    "wof:lastmodified":1607983944,
     "wof:name":"Tallinn",
     "wof:parent_id":85683055,
     "wof:placetype":"county",

--- a/data/171/330/564/7/1713305647.geojson
+++ b/data/171/330/564/7/1713305647.geojson
@@ -51,6 +51,10 @@
     "wof:concordances":{
         "ee-mamt:okood":446
     },
+    "wof:coterminous":[
+        101753891,
+        1713313119
+    ],
     "wof:country":"EE",
     "wof:created":1595451872,
     "wof:geomhash":"1219f1125adf2ee7d47a5ae14fbfc395",
@@ -69,7 +73,7 @@
     "wof:lang_x_spoken":[
         "est"
     ],
-    "wof:lastmodified":1596663471,
+    "wof:lastmodified":1607984289,
     "wof:name":"Maardu",
     "wof:parent_id":85683055,
     "wof:placetype":"county",

--- a/data/171/330/564/9/1713305649.geojson
+++ b/data/171/330/564/9/1713305649.geojson
@@ -51,6 +51,10 @@
     "wof:concordances":{
         "ee-mamt:okood":424
     },
+    "wof:coterminous":[
+        101815171,
+        1713313739
+    ],
     "wof:country":"EE",
     "wof:created":1595451873,
     "wof:geomhash":"34fad119e34017d7b37b276b16b52f2c",
@@ -69,7 +73,7 @@
     "wof:lang_x_spoken":[
         "est"
     ],
-    "wof:lastmodified":1596663467,
+    "wof:lastmodified":1607984295,
     "wof:name":"Loksa",
     "wof:parent_id":85683055,
     "wof:placetype":"county",

--- a/data/171/330/566/7/1713305667.geojson
+++ b/data/171/330/566/7/1713305667.geojson
@@ -51,6 +51,10 @@
     "wof:concordances":{
         "ee-mamt:okood":663
     },
+    "wof:coterminous":[
+        101839837,
+        1713314069
+    ],
     "wof:country":"EE",
     "wof:created":1595451877,
     "wof:geomhash":"971352196e8e86bbe9d8dba0c4887cfb",
@@ -69,7 +73,7 @@
     "wof:lang_x_spoken":[
         "est"
     ],
-    "wof:lastmodified":1596661276,
+    "wof:lastmodified":1607984074,
     "wof:name":"Rakvere",
     "wof:parent_id":85683049,
     "wof:placetype":"county",

--- a/data/171/330/567/1/1713305671.geojson
+++ b/data/171/330/567/1/1713305671.geojson
@@ -51,6 +51,10 @@
     "wof:concordances":{
         "ee-mamt:okood":511
     },
+    "wof:coterminous":[
+        101748155,
+        1713314091
+    ],
     "wof:country":"EE",
     "wof:created":1595451878,
     "wof:geomhash":"8bb652e7b3c25d1a156249e012a0aa23",
@@ -69,7 +73,7 @@
     "wof:lang_x_spoken":[
         "est"
     ],
-    "wof:lastmodified":1596661044,
+    "wof:lastmodified":1607984096,
     "wof:name":"Narva",
     "wof:parent_id":85683059,
     "wof:placetype":"county",

--- a/data/171/330/572/9/1713305729.geojson
+++ b/data/171/330/572/9/1713305729.geojson
@@ -51,6 +51,10 @@
     "wof:concordances":{
         "ee-mamt:okood":735
     },
+    "wof:coterminous":[
+        101815211,
+        1713314929
+    ],
     "wof:country":"EE",
     "wof:created":1595451897,
     "wof:geomhash":"37392de1680176a20f237df99324ff60",
@@ -69,7 +73,7 @@
     "wof:lang_x_spoken":[
         "est"
     ],
-    "wof:lastmodified":1596661508,
+    "wof:lastmodified":1607984266,
     "wof:name":"Sillam\u00e4e",
     "wof:parent_id":85683059,
     "wof:placetype":"county",

--- a/data/171/330/574/3/1713305743.geojson
+++ b/data/171/330/574/3/1713305743.geojson
@@ -51,6 +51,10 @@
     "wof:concordances":{
         "ee-mamt:okood":296
     },
+    "wof:coterminous":[
+        101815187,
+        1713315095
+    ],
     "wof:country":"EE",
     "wof:created":1595451902,
     "wof:geomhash":"e33282223a9b64621f7081e0545ad58c",
@@ -69,7 +73,7 @@
     "wof:lang_x_spoken":[
         "est"
     ],
-    "wof:lastmodified":1596663218,
+    "wof:lastmodified":1607984165,
     "wof:name":"Keila",
     "wof:parent_id":85683055,
     "wof:placetype":"county",

--- a/data/171/330/578/5/1713305785.geojson
+++ b/data/171/330/578/5/1713305785.geojson
@@ -51,6 +51,10 @@
     "wof:concordances":{
         "ee-mamt:okood":919
     },
+    "wof:coterminous":[
+        101816257,
+        1713315923
+    ],
     "wof:country":"EE",
     "wof:created":1595451916,
     "wof:geomhash":"bfd929592b56bb33a1136bc7fc43eeb3",
@@ -69,7 +73,7 @@
     "wof:lang_x_spoken":[
         "est"
     ],
-    "wof:lastmodified":1596676915,
+    "wof:lastmodified":1607983998,
     "wof:name":"V\u0151ru",
     "wof:parent_id":85682937,
     "wof:placetype":"county",

--- a/data/171/330/622/1/1713306221.geojson
+++ b/data/171/330/622/1/1713306221.geojson
@@ -42,15 +42,16 @@
     "wof:belongsto":[
         102191581,
         85633135,
-        85682947,
-        1713305621
+        1713305621,
+        85682947
     ],
     "wof:breaches":[],
     "wof:concordances":{
         "ee-mamt:okood":7105
     },
     "wof:coterminous":[
-        1126037823
+        1126037823,
+        1713305621
     ],
     "wof:country":"EE",
     "wof:created":1595459106,
@@ -71,7 +72,7 @@
     "wof:lang_x_spoken":[
         "est"
     ],
-    "wof:lastmodified":1596675092,
+    "wof:lastmodified":1607984736,
     "wof:name":"Ruhnu",
     "wof:parent_id":1713305621,
     "wof:placetype":"localadmin",

--- a/data/171/331/291/7/1713312917.geojson
+++ b/data/171/331/291/7/1713312917.geojson
@@ -42,13 +42,17 @@
     "wof:belongsto":[
         102191581,
         85633135,
-        85682985,
-        1713305641
+        1713305641,
+        85682985
     ],
     "wof:breaches":[],
     "wof:concordances":{
         "ee-mamt:okood":897
     },
+    "wof:coterminous":[
+        101815089,
+        1713305641
+    ],
     "wof:country":"EE",
     "wof:created":1595460651,
     "wof:geomhash":"b25ce560c9cc4e69d5625da7fa6115a1",
@@ -68,7 +72,7 @@
     "wof:lang_x_spoken":[
         "est"
     ],
-    "wof:lastmodified":1596663491,
+    "wof:lastmodified":1607984254,
     "wof:name":"Viljandi",
     "wof:parent_id":1713305641,
     "wof:placetype":"localadmin",

--- a/data/171/331/311/9/1713313119.geojson
+++ b/data/171/331/311/9/1713313119.geojson
@@ -42,13 +42,17 @@
     "wof:belongsto":[
         102191581,
         85633135,
-        85683055,
-        1713305647
+        1713305647,
+        85683055
     ],
     "wof:breaches":[],
     "wof:concordances":{
         "ee-mamt:okood":446
     },
+    "wof:coterminous":[
+        101753891,
+        1713305647
+    ],
     "wof:country":"EE",
     "wof:created":1595460694,
     "wof:geomhash":"1219f1125adf2ee7d47a5ae14fbfc395",
@@ -68,7 +72,7 @@
     "wof:lang_x_spoken":[
         "est"
     ],
-    "wof:lastmodified":1596663473,
+    "wof:lastmodified":1607984289,
     "wof:name":"Maardu",
     "wof:parent_id":1713305647,
     "wof:placetype":"localadmin",

--- a/data/171/331/373/9/1713313739.geojson
+++ b/data/171/331/373/9/1713313739.geojson
@@ -42,13 +42,17 @@
     "wof:belongsto":[
         102191581,
         85633135,
-        85683055,
-        1713305649
+        1713305649,
+        85683055
     ],
     "wof:breaches":[],
     "wof:concordances":{
         "ee-mamt:okood":424
     },
+    "wof:coterminous":[
+        101815171,
+        1713305649
+    ],
     "wof:country":"EE",
     "wof:created":1595460825,
     "wof:geomhash":"34fad119e34017d7b37b276b16b52f2c",
@@ -68,7 +72,7 @@
     "wof:lang_x_spoken":[
         "est"
     ],
-    "wof:lastmodified":1596663469,
+    "wof:lastmodified":1607984295,
     "wof:name":"Loksa",
     "wof:parent_id":1713305649,
     "wof:placetype":"localadmin",

--- a/data/171/331/406/9/1713314069.geojson
+++ b/data/171/331/406/9/1713314069.geojson
@@ -42,13 +42,17 @@
     "wof:belongsto":[
         102191581,
         85633135,
-        85683049,
-        1713305667
+        1713305667,
+        85683049
     ],
     "wof:breaches":[],
     "wof:concordances":{
         "ee-mamt:okood":663
     },
+    "wof:coterminous":[
+        101839837,
+        1713305667
+    ],
     "wof:country":"EE",
     "wof:created":1595460896,
     "wof:geomhash":"5de5b79d9c3b6e3d90182aa7f4ca5170",
@@ -68,7 +72,7 @@
     "wof:lang_x_spoken":[
         "est"
     ],
-    "wof:lastmodified":1596661277,
+    "wof:lastmodified":1607984074,
     "wof:name":"Rakvere",
     "wof:parent_id":1713305667,
     "wof:placetype":"localadmin",

--- a/data/171/331/409/1/1713314091.geojson
+++ b/data/171/331/409/1/1713314091.geojson
@@ -42,13 +42,17 @@
     "wof:belongsto":[
         102191581,
         85633135,
-        85683059,
-        1713305671
+        1713305671,
+        85683059
     ],
     "wof:breaches":[],
     "wof:concordances":{
         "ee-mamt:okood":511
     },
+    "wof:coterminous":[
+        101748155,
+        1713305671
+    ],
     "wof:country":"EE",
     "wof:created":1595460901,
     "wof:geomhash":"cf568100b88ab2fb3e0943cc7fcf0bd4",
@@ -68,7 +72,7 @@
     "wof:lang_x_spoken":[
         "est"
     ],
-    "wof:lastmodified":1596661050,
+    "wof:lastmodified":1607984095,
     "wof:name":"Narva",
     "wof:parent_id":1713305671,
     "wof:placetype":"localadmin",

--- a/data/171/331/492/9/1713314929.geojson
+++ b/data/171/331/492/9/1713314929.geojson
@@ -42,13 +42,17 @@
     "wof:belongsto":[
         102191581,
         85633135,
-        85683059,
-        1713305729
+        1713305729,
+        85683059
     ],
     "wof:breaches":[],
     "wof:concordances":{
         "ee-mamt:okood":735
     },
+    "wof:coterminous":[
+        101815211,
+        1713305729
+    ],
     "wof:country":"EE",
     "wof:created":1595461096,
     "wof:geomhash":"37392de1680176a20f237df99324ff60",
@@ -68,7 +72,7 @@
     "wof:lang_x_spoken":[
         "est"
     ],
-    "wof:lastmodified":1596661509,
+    "wof:lastmodified":1607984265,
     "wof:name":"Sillam\u00e4e",
     "wof:parent_id":1713305729,
     "wof:placetype":"localadmin",

--- a/data/171/331/509/5/1713315095.geojson
+++ b/data/171/331/509/5/1713315095.geojson
@@ -42,13 +42,17 @@
     "wof:belongsto":[
         102191581,
         85633135,
-        85683055,
-        1713305743
+        1713305743,
+        85683055
     ],
     "wof:breaches":[],
     "wof:concordances":{
         "ee-mamt:okood":296
     },
+    "wof:coterminous":[
+        101815187,
+        1713305743
+    ],
     "wof:country":"EE",
     "wof:created":1595461131,
     "wof:geomhash":"665d87f6a777feb1dc2e34a1927708db",
@@ -68,7 +72,7 @@
     "wof:lang_x_spoken":[
         "est"
     ],
-    "wof:lastmodified":1596663219,
+    "wof:lastmodified":1607984165,
     "wof:name":"Keila",
     "wof:parent_id":1713305743,
     "wof:placetype":"localadmin",

--- a/data/171/331/592/3/1713315923.geojson
+++ b/data/171/331/592/3/1713315923.geojson
@@ -42,13 +42,17 @@
     "wof:belongsto":[
         102191581,
         85633135,
-        85682937,
-        1713305785
+        1713305785,
+        85682937
     ],
     "wof:breaches":[],
     "wof:concordances":{
         "ee-mamt:okood":919
     },
+    "wof:coterminous":[
+        101816257,
+        1713305785
+    ],
     "wof:country":"EE",
     "wof:created":1595461322,
     "wof:geomhash":"08293646daaf31726dd8eb1923a32a77",
@@ -68,7 +72,7 @@
     "wof:lang_x_spoken":[
         "est"
     ],
-    "wof:lastmodified":1596676915,
+    "wof:lastmodified":1607983998,
     "wof:name":"V\u0151ru",
     "wof:parent_id":1713305785,
     "wof:placetype":"localadmin",


### PR DESCRIPTION
Fixes a portion of whosonfirst-data/whosonfirst-data#1906.

This PR attempts flag any locality, localadmin, county, macrocounty, or region record as coterminous with any parent records that are similar in size and have similar names.