### PR TITLE
WIP: Move centroids inside geometries

### DIFF
--- a/data/101/839/155/101839155.geojson
+++ b/data/101/839/155/101839155.geojson
@@ -11,8 +11,8 @@
     "geom:longitude":26.43127,
     "gn:population":1350,
     "iso:country":"EE",
-    "lbl:latitude":59.362511,
-    "lbl:longitude":26.402993,
+    "lbl:latitude":59.360052,
+    "lbl:longitude":26.431609,
     "lbl:max_zoom":16.0,
     "lbl:min_zoom":12.0,
     "mps:latitude":59.360052,
@@ -133,7 +133,7 @@
     "wof:lang_x_spoken":[
         "est"
     ],
-    "wof:lastmodified":1690875709,
+    "wof:lastmodified":1694320348,
     "wof:name":"S\u00f5meru",
     "wof:parent_id":1713314237,
     "wof:placetype":"locality",

--- a/data/101/846/687/101846687.geojson
+++ b/data/101/846/687/101846687.geojson
@@ -12,8 +12,8 @@
     "gn:id":"587571,587572",
     "gn:population":1032,
     "iso:country":"EE",
-    "lbl:latitude":59.282603,
-    "lbl:longitude":26.411628,
+    "lbl:latitude":59.295524,
+    "lbl:longitude":26.423931,
     "lbl:max_zoom":16.0,
     "lbl:min_zoom":12.0,
     "mps:latitude":59.295524,
@@ -127,7 +127,7 @@
     "wof:lang_x_spoken":[
         "est"
     ],
-    "wof:lastmodified":1690875688,
+    "wof:lastmodified":1694320348,
     "wof:name":"Vinni",
     "wof:parent_id":1713307879,
     "wof:placetype":"locality",

--- a/data/112/576/745/9/1125767459.geojson
+++ b/data/112/576/745/9/1125767459.geojson
@@ -13,8 +13,8 @@
     "gn:fcode":"PPL",
     "gn:population":461,
     "iso:country":"EE",
-    "lbl:latitude":58.78806,
-    "lbl:longitude":26.48417,
+    "lbl:latitude":58.785169,
+    "lbl:longitude":26.495924,
     "lbl:max_zoom":17.0,
     "lbl:min_zoom":12.5,
     "mps:latitude":58.785169,
@@ -99,7 +99,7 @@
     "src:geom_alt":[
         "qs_pg"
     ],
-    "src:lbl_centroid":"qs_pg",
+    "src:lbl_centroid":"mapshaper",
     "src:population":"geonames",
     "woe:adm0_id":23424805,
     "woe:name_adm0":"Eesti",
@@ -145,7 +145,7 @@
     "wof:lang_x_spoken":[
         "est"
     ],
-    "wof:lastmodified":1690875875,
+    "wof:lastmodified":1694320348,
     "wof:name":"Laiuse",
     "wof:parent_id":1713312361,
     "wof:placetype":"locality",

--- a/data/112/581/705/3/1125817053.geojson
+++ b/data/112/581/705/3/1125817053.geojson
@@ -13,8 +13,8 @@
     "gn:fcode":"PPL",
     "gn:population":488,
     "iso:country":"EE",
-    "lbl:latitude":59.02722,
-    "lbl:longitude":25.70833,
+    "lbl:latitude":59.029542,
+    "lbl:longitude":25.712827,
     "lbl:max_zoom":17.0,
     "lbl:min_zoom":12.5,
     "mps:latitude":59.029542,
@@ -83,7 +83,7 @@
     "src:geom_alt":[
         "qs_pg"
     ],
-    "src:lbl_centroid":"qs_pg",
+    "src:lbl_centroid":"mapshaper",
     "src:population":"geonames",
     "woe:adm0_id":23424805,
     "woe:name_adm0":"Eesti",
@@ -128,7 +128,7 @@
     "wof:lang_x_spoken":[
         "est"
     ],
-    "wof:lastmodified":1596661326,
+    "wof:lastmodified":1694320348,
     "wof:name":"Roosna-Alliku",
     "wof:parent_id":1713308375,
     "wof:placetype":"locality",

--- a/data/112/587/145/5/1125871455.geojson
+++ b/data/112/587/145/5/1125871455.geojson
@@ -13,8 +13,8 @@
     "gn:fcode":"PPL",
     "gn:population":968,
     "iso:country":"EE",
-    "lbl:latitude":58.97028,
-    "lbl:longitude":23.90333,
+    "lbl:latitude":58.963939,
+    "lbl:longitude":23.895923,
     "lbl:max_zoom":17.0,
     "lbl:min_zoom":12.5,
     "mps:latitude":58.963939,
@@ -93,7 +93,7 @@
     "src:geom_alt":[
         "qs_pg"
     ],
-    "src:lbl_centroid":"qs_pg",
+    "src:lbl_centroid":"mapshaper",
     "src:population":"geonames",
     "woe:adm0_id":23424805,
     "woe:name_adm0":"Eesti",
@@ -139,7 +139,7 @@
     "wof:lang_x_spoken":[
         "est"
     ],
-    "wof:lastmodified":1690875825,
+    "wof:lastmodified":1694320348,
     "wof:name":"Palivere",
     "wof:parent_id":1713309119,
     "wof:placetype":"locality",

--- a/data/112/588/988/5/1125889885.geojson
+++ b/data/112/588/988/5/1125889885.geojson
@@ -13,8 +13,8 @@
     "gn:fcode":"PPL",
     "gn:population":854,
     "iso:country":"EE",
-    "lbl:latitude":58.82556,
-    "lbl:longitude":22.78972,
+    "lbl:latitude":58.826344,
+    "lbl:longitude":22.777843,
     "lbl:max_zoom":17.0,
     "lbl:min_zoom":12.5,
     "mps:latitude":58.826344,
@@ -102,7 +102,7 @@
     "src:geom_alt":[
         "qs_pg"
     ],
-    "src:lbl_centroid":"qs_pg",
+    "src:lbl_centroid":"mapshaper",
     "src:population":"geonames",
     "woe:adm0_id":23424805,
     "woe:name_adm0":"Eesti",
@@ -148,7 +148,7 @@
     "wof:lang_x_spoken":[
         "est"
     ],
-    "wof:lastmodified":1690875810,
+    "wof:lastmodified":1694320348,
     "wof:name":"K\u00e4ina",
     "wof:parent_id":1713310383,
     "wof:placetype":"locality",

--- a/data/112/589/003/5/1125890035.geojson
+++ b/data/112/589/003/5/1125890035.geojson
@@ -13,12 +13,12 @@
     "gn:fcode":"PPL",
     "gn:population":679,
     "iso:country":"EE",
-    "lbl:latitude":58.88556,
-    "lbl:longitude":25.44639,
+    "lbl:latitude":58.893555,
+    "lbl:longitude":25.455508,
     "lbl:max_zoom":17.0,
     "lbl:min_zoom":12.5,
     "mps:latitude":58.893555,
-    "mps:longitude":25.455507,
+    "mps:longitude":25.455508,
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
@@ -102,7 +102,7 @@
     "src:geom_alt":[
         "qs_pg"
     ],
-    "src:lbl_centroid":"qs_pg",
+    "src:lbl_centroid":"mapshaper",
     "src:population":"geonames",
     "woe:adm0_id":23424805,
     "woe:name_adm0":"Eesti",
@@ -148,7 +148,7 @@
     "wof:lang_x_spoken":[
         "est"
     ],
-    "wof:lastmodified":1690875817,
+    "wof:lastmodified":1694320348,
     "wof:name":"V\u00e4\u00e4tsa",
     "wof:parent_id":1713315891,
     "wof:placetype":"locality",

--- a/data/112/589/038/1/1125890381.geojson
+++ b/data/112/589/038/1/1125890381.geojson
@@ -13,8 +13,8 @@
     "gn:fcode":"PPL",
     "gn:population":487,
     "iso:country":"EE",
-    "lbl:latitude":58.48917,
-    "lbl:longitude":26.67028,
+    "lbl:latitude":58.497076,
+    "lbl:longitude":26.681903,
     "lbl:max_zoom":17.0,
     "lbl:min_zoom":12.5,
     "mps:latitude":58.497076,
@@ -87,7 +87,7 @@
     "src:geom_alt":[
         "qs_pg"
     ],
-    "src:lbl_centroid":"qs_pg",
+    "src:lbl_centroid":"mapshaper",
     "src:population":"geonames",
     "woe:adm0_id":23424805,
     "woe:name_adm0":"Eesti",
@@ -133,7 +133,7 @@
     "wof:lang_x_spoken":[
         "est"
     ],
-    "wof:lastmodified":1690875815,
+    "wof:lastmodified":1694320348,
     "wof:name":"L\u00e4hte",
     "wof:parent_id":1713309083,
     "wof:placetype":"locality",

--- a/data/112/589/052/7/1125890527.geojson
+++ b/data/112/589/052/7/1125890527.geojson
@@ -13,8 +13,8 @@
     "gn:fcode":"PPL",
     "gn:population":112,
     "iso:country":"EE",
-    "lbl:latitude":58.07833,
-    "lbl:longitude":27.54528,
+    "lbl:latitude":58.081967,
+    "lbl:longitude":27.538433,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.0,
     "mps:latitude":58.081967,
@@ -99,7 +99,7 @@
     "src:geom_alt":[
         "qs_pg"
     ],
-    "src:lbl_centroid":"qs_pg",
+    "src:lbl_centroid":"mapshaper",
     "src:population":"geonames",
     "woe:adm0_id":23424805,
     "woe:name_adm0":"Eesti",
@@ -145,7 +145,7 @@
     "wof:lang_x_spoken":[
         "est"
     ],
-    "wof:lastmodified":1690875815,
+    "wof:lastmodified":1694320349,
     "wof:name":"V\u00f5\u00f5psu",
     "wof:parent_id":1713316461,
     "wof:placetype":"locality",

--- a/data/112/591/092/9/1125910929.geojson
+++ b/data/112/591/092/9/1125910929.geojson
@@ -13,12 +13,12 @@
     "gn:fcode":"PPL",
     "gn:population":576,
     "iso:country":"EE",
-    "lbl:latitude":58.16139,
-    "lbl:longitude":22.26222,
+    "lbl:latitude":58.160778,
+    "lbl:longitude":22.247794,
     "lbl:max_zoom":17.0,
     "lbl:min_zoom":12.5,
-    "mps:latitude":58.160779,
-    "mps:longitude":22.247795,
+    "mps:latitude":58.160778,
+    "mps:longitude":22.247794,
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
@@ -108,7 +108,7 @@
     "src:geom_alt":[
         "qs_pg"
     ],
-    "src:lbl_centroid":"qs_pg",
+    "src:lbl_centroid":"mapshaper",
     "src:population":"geonames",
     "woe:adm0_id":23424805,
     "woe:name_adm0":"Eesti",
@@ -148,7 +148,7 @@
     "wof:lang_x_spoken":[
         "est"
     ],
-    "wof:lastmodified":1690875844,
+    "wof:lastmodified":1694320349,
     "wof:name":"Salme",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/112/593/555/7/1125935557.geojson
+++ b/data/112/593/555/7/1125935557.geojson
@@ -13,8 +13,8 @@
     "gn:fcode":"PPL",
     "gn:population":406,
     "iso:country":"EE",
-    "lbl:latitude":59.18833,
-    "lbl:longitude":24.805,
+    "lbl:latitude":59.179614,
+    "lbl:longitude":24.800218,
     "lbl:max_zoom":17.0,
     "lbl:min_zoom":12.5,
     "mps:latitude":59.179614,
@@ -85,7 +85,7 @@
     "src:geom_alt":[
         "qs_pg"
     ],
-    "src:lbl_centroid":"qs_pg",
+    "src:lbl_centroid":"mapshaper",
     "src:population":"geonames",
     "woe:adm0_id":23424805,
     "woe:name_adm0":"Eesti",
@@ -131,7 +131,7 @@
     "wof:lang_x_spoken":[
         "est"
     ],
-    "wof:lastmodified":1690875729,
+    "wof:lastmodified":1694320349,
     "wof:name":"Prillim\u00e4e",
     "wof:parent_id":1713313249,
     "wof:placetype":"locality",

--- a/data/112/593/606/5/1125936065.geojson
+++ b/data/112/593/606/5/1125936065.geojson
@@ -13,12 +13,12 @@
     "gn:fcode":"PPL",
     "gn:population":495,
     "iso:country":"EE",
-    "lbl:latitude":59.15861,
-    "lbl:longitude":26.15389,
+    "lbl:latitude":59.156251,
+    "lbl:longitude":26.135669,
     "lbl:max_zoom":17.0,
     "lbl:min_zoom":12.5,
-    "mps:latitude":59.156252,
-    "mps:longitude":26.13567,
+    "mps:latitude":59.156251,
+    "mps:longitude":26.135669,
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
@@ -88,7 +88,7 @@
     "src:geom_alt":[
         "qs_pg"
     ],
-    "src:lbl_centroid":"qs_pg",
+    "src:lbl_centroid":"mapshaper",
     "src:population":"geonames",
     "woe:adm0_id":23424805,
     "woe:name_adm0":"Eesti",
@@ -134,7 +134,7 @@
     "wof:lang_x_spoken":[
         "est"
     ],
-    "wof:lastmodified":1690875737,
+    "wof:lastmodified":1694320349,
     "wof:name":"S\u00e4\u00e4se",
     "wof:parent_id":1713308119,
     "wof:placetype":"locality",

--- a/data/112/593/653/9/1125936539.geojson
+++ b/data/112/593/653/9/1125936539.geojson
@@ -13,8 +13,8 @@
     "gn:fcode":"PPL",
     "gn:population":533,
     "iso:country":"EE",
-    "lbl:latitude":58.81278,
-    "lbl:longitude":26.73833,
+    "lbl:latitude":58.821045,
+    "lbl:longitude":26.732482,
     "lbl:max_zoom":17.0,
     "lbl:min_zoom":12.5,
     "mps:latitude":58.821045,
@@ -115,7 +115,7 @@
     "src:geom_alt":[
         "qs_pg"
     ],
-    "src:lbl_centroid":"qs_pg",
+    "src:lbl_centroid":"mapshaper",
     "src:population":"geonames",
     "woe:adm0_id":23424805,
     "woe:name_adm0":"Eesti",
@@ -161,7 +161,7 @@
     "wof:lang_x_spoken":[
         "est"
     ],
-    "wof:lastmodified":1690875737,
+    "wof:lastmodified":1694320349,
     "wof:name":"Torma",
     "wof:parent_id":1713314267,
     "wof:placetype":"locality",

--- a/data/112/593/823/5/1125938235.geojson
+++ b/data/112/593/823/5/1125938235.geojson
@@ -13,11 +13,11 @@
     "gn:fcode":"PPL",
     "gn:population":732,
     "iso:country":"EE",
-    "lbl:latitude":58.30583,
-    "lbl:longitude":25.53528,
+    "lbl:latitude":58.307809,
+    "lbl:longitude":25.542931,
     "lbl:max_zoom":17.0,
     "lbl:min_zoom":12.5,
-    "mps:latitude":58.30781,
+    "mps:latitude":58.307809,
     "mps:longitude":25.542931,
     "mz:hierarchy_label":1,
     "mz:is_current":1,
@@ -71,7 +71,7 @@
     "src:geom_alt":[
         "qs_pg"
     ],
-    "src:lbl_centroid":"qs_pg",
+    "src:lbl_centroid":"mapshaper",
     "src:population":"geonames",
     "woe:adm0_id":23424805,
     "woe:name_adm0":"Eesti",
@@ -116,7 +116,7 @@
     "wof:lang_x_spoken":[
         "est"
     ],
-    "wof:lastmodified":1596661272,
+    "wof:lastmodified":1694320349,
     "wof:name":"Ramsi",
     "wof:parent_id":1713314301,
     "wof:placetype":"locality",

--- a/data/112/596/181/9/1125961819.geojson
+++ b/data/112/596/181/9/1125961819.geojson
@@ -13,8 +13,8 @@
     "gn:fcode":"PPL",
     "gn:population":594,
     "iso:country":"EE",
-    "lbl:latitude":58.73667,
-    "lbl:longitude":26.5225,
+    "lbl:latitude":58.737614,
+    "lbl:longitude":26.534952,
     "lbl:max_zoom":17.0,
     "lbl:min_zoom":12.5,
     "mps:latitude":58.737614,
@@ -87,7 +87,7 @@
     "src:geom_alt":[
         "qs_pg"
     ],
-    "src:lbl_centroid":"qs_pg",
+    "src:lbl_centroid":"mapshaper",
     "src:population":"geonames",
     "woe:adm0_id":23424805,
     "woe:name_adm0":"Eesti",
@@ -133,7 +133,7 @@
     "wof:lang_x_spoken":[
         "est"
     ],
-    "wof:lastmodified":1690875841,
+    "wof:lastmodified":1694320349,
     "wof:name":"Kuremaa",
     "wof:parent_id":1713312069,
     "wof:placetype":"locality",

--- a/data/112/596/847/3/1125968473.geojson
+++ b/data/112/596/847/3/1125968473.geojson
@@ -13,8 +13,8 @@
     "gn:fcode":"PPL",
     "gn:population":1016,
     "iso:country":"EE",
-    "lbl:latitude":59.29056,
-    "lbl:longitude":24.96583,
+    "lbl:latitude":59.289102,
+    "lbl:longitude":24.974326,
     "lbl:max_zoom":16.0,
     "lbl:min_zoom":12.0,
     "mps:latitude":59.289102,
@@ -95,7 +95,7 @@
     "src:geom_alt":[
         "qs_pg"
     ],
-    "src:lbl_centroid":"qs_pg",
+    "src:lbl_centroid":"mapshaper",
     "src:population":"geonames",
     "woe:adm0_id":23424805,
     "woe:name_adm0":"Eesti",
@@ -141,7 +141,7 @@
     "wof:lang_x_spoken":[
         "est"
     ],
-    "wof:lastmodified":1690875841,
+    "wof:lastmodified":1694320349,
     "wof:name":"Vaida",
     "wof:parent_id":1713313187,
     "wof:placetype":"locality",

--- a/data/112/597/156/5/1125971565.geojson
+++ b/data/112/597/156/5/1125971565.geojson
@@ -13,8 +13,8 @@
     "gn:fcode":"PPL",
     "gn:population":418,
     "iso:country":"EE",
-    "lbl:latitude":58.75361,
-    "lbl:longitude":25.565,
+    "lbl:latitude":58.758935,
+    "lbl:longitude":25.56464,
     "lbl:max_zoom":17.0,
     "lbl:min_zoom":12.5,
     "mps:latitude":58.758935,
@@ -85,7 +85,7 @@
     "src:geom_alt":[
         "qs_pg"
     ],
-    "src:lbl_centroid":"qs_pg",
+    "src:lbl_centroid":"mapshaper",
     "src:population":"geonames",
     "woe:adm0_id":23424805,
     "woe:name_adm0":"Eesti",
@@ -131,7 +131,7 @@
     "wof:lang_x_spoken":[
         "est"
     ],
-    "wof:lastmodified":1690875834,
+    "wof:lastmodified":1694320349,
     "wof:name":"Oisu",
     "wof:parent_id":1713306597,
     "wof:placetype":"locality",

--- a/data/112/600/359/1/1126003591.geojson
+++ b/data/112/600/359/1/1126003591.geojson
@@ -13,8 +13,8 @@
     "gn:fcode":"PPL",
     "gn:population":96,
     "iso:country":"EE",
-    "lbl:latitude":59.07167,
-    "lbl:longitude":24.81833,
+    "lbl:latitude":59.066774,
+    "lbl:longitude":24.81288,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.0,
     "mps:latitude":59.066774,
@@ -93,7 +93,7 @@
     "src:geom_alt":[
         "qs_pg"
     ],
-    "src:lbl_centroid":"qs_pg",
+    "src:lbl_centroid":"mapshaper",
     "src:population":"geonames",
     "woe:adm0_id":23424805,
     "woe:name_adm0":"Eesti",
@@ -139,7 +139,7 @@
     "wof:lang_x_spoken":[
         "est"
     ],
-    "wof:lastmodified":1690875861,
+    "wof:lastmodified":1694320349,
     "wof:name":"Hagudi",
     "wof:parent_id":1713313315,
     "wof:placetype":"locality",

--- a/data/112/600/830/1/1126008301.geojson
+++ b/data/112/600/830/1/1126008301.geojson
@@ -13,8 +13,8 @@
     "gn:fcode":"PPL",
     "gn:population":453,
     "iso:country":"EE",
-    "lbl:latitude":58.52694,
-    "lbl:longitude":26.64417,
+    "lbl:latitude":58.525517,
+    "lbl:longitude":26.671938,
     "lbl:max_zoom":17.0,
     "lbl:min_zoom":12.5,
     "mps:latitude":58.525517,
@@ -93,7 +93,7 @@
     "src:geom_alt":[
         "qs_pg"
     ],
-    "src:lbl_centroid":"qs_pg",
+    "src:lbl_centroid":"mapshaper",
     "src:population":"geonames",
     "woe:adm0_id":23424805,
     "woe:name_adm0":"Eesti",
@@ -139,7 +139,7 @@
     "wof:lang_x_spoken":[
         "est"
     ],
-    "wof:lastmodified":1690875866,
+    "wof:lastmodified":1694320349,
     "wof:name":"\u00c4ksi",
     "wof:parent_id":1713313673,
     "wof:placetype":"locality",

--- a/data/112/600/830/7/1126008307.geojson
+++ b/data/112/600/830/7/1126008307.geojson
@@ -13,8 +13,8 @@
     "gn:fcode":"PPL",
     "gn:population":546,
     "iso:country":"EE",
-    "lbl:latitude":58.34361,
-    "lbl:longitude":22.45889,
+    "lbl:latitude":58.34666,
+    "lbl:longitude":22.445464,
     "lbl:max_zoom":17.0,
     "lbl:min_zoom":12.5,
     "mps:latitude":58.34666,
@@ -96,7 +96,7 @@
     "src:geom_alt":[
         "qs_pg"
     ],
-    "src:lbl_centroid":"qs_pg",
+    "src:lbl_centroid":"mapshaper",
     "src:population":"geonames",
     "woe:adm0_id":23424805,
     "woe:name_adm0":"Eesti",
@@ -142,7 +142,7 @@
     "wof:lang_x_spoken":[
         "est"
     ],
-    "wof:lastmodified":1690875865,
+    "wof:lastmodified":1694320349,
     "wof:name":"Aste",
     "wof:parent_id":1713306599,
     "wof:placetype":"locality",

--- a/data/112/600/840/1/1126008401.geojson
+++ b/data/112/600/840/1/1126008401.geojson
@@ -13,8 +13,8 @@
     "gn:fcode":"PPL",
     "gn:population":571,
     "iso:country":"EE",
-    "lbl:latitude":58.42417,
-    "lbl:longitude":26.78222,
+    "lbl:latitude":58.424179,
+    "lbl:longitude":26.767459,
     "lbl:max_zoom":17.0,
     "lbl:min_zoom":12.5,
     "mps:latitude":58.424179,
@@ -87,7 +87,7 @@
     "src:geom_alt":[
         "qs_pg"
     ],
-    "src:lbl_centroid":"qs_pg",
+    "src:lbl_centroid":"mapshaper",
     "src:population":"geonames",
     "woe:adm0_id":23424805,
     "woe:name_adm0":"Eesti",
@@ -133,7 +133,7 @@
     "wof:lang_x_spoken":[
         "est"
     ],
-    "wof:lastmodified":1690875864,
+    "wof:lastmodified":1694320349,
     "wof:name":"K\u00f5rvek\u00fcla",
     "wof:parent_id":1713313829,
     "wof:placetype":"locality",

--- a/data/112/600/859/9/1126008599.geojson
+++ b/data/112/600/859/9/1126008599.geojson
@@ -13,8 +13,8 @@
     "gn:fcode":"PPL",
     "gn:population":377,
     "iso:country":"EE",
-    "lbl:latitude":59.17861,
-    "lbl:longitude":25.21639,
+    "lbl:latitude":59.183366,
+    "lbl:longitude":25.222684,
     "lbl:max_zoom":17.0,
     "lbl:min_zoom":12.5,
     "mps:latitude":59.183366,
@@ -93,7 +93,7 @@
     "src:geom_alt":[
         "qs_pg"
     ],
-    "src:lbl_centroid":"qs_pg",
+    "src:lbl_centroid":"mapshaper",
     "src:population":"geonames",
     "woe:adm0_id":23424805,
     "woe:name_adm0":"Eesti",
@@ -139,7 +139,7 @@
     "wof:lang_x_spoken":[
         "est"
     ],
-    "wof:lastmodified":1690875857,
+    "wof:lastmodified":1694320349,
     "wof:name":"Ravila",
     "wof:parent_id":1713306307,
     "wof:placetype":"locality",

--- a/data/112/601/766/7/1126017667.geojson
+++ b/data/112/601/766/7/1126017667.geojson
@@ -13,8 +13,8 @@
     "gn:fcode":"PPL",
     "gn:population":210,
     "iso:country":"EE",
-    "lbl:latitude":58.97556,
-    "lbl:longitude":24.71861,
+    "lbl:latitude":58.971035,
+    "lbl:longitude":24.720271,
     "lbl:max_zoom":17.0,
     "lbl:min_zoom":12.5,
     "mps:latitude":58.971035,
@@ -90,7 +90,7 @@
     "src:geom_alt":[
         "qs_pg"
     ],
-    "src:lbl_centroid":"qs_pg",
+    "src:lbl_centroid":"mapshaper",
     "src:population":"geonames",
     "woe:adm0_id":23424805,
     "woe:name_adm0":"Eesti",
@@ -136,7 +136,7 @@
     "wof:lang_x_spoken":[
         "est"
     ],
-    "wof:lastmodified":1690875851,
+    "wof:lastmodified":1694320349,
     "wof:name":"Kuusiku",
     "wof:parent_id":1713311405,
     "wof:placetype":"locality",

--- a/data/112/601/770/3/1126017703.geojson
+++ b/data/112/601/770/3/1126017703.geojson
@@ -13,8 +13,8 @@
     "gn:fcode":"PPL",
     "gn:population":233,
     "iso:country":"EE",
-    "lbl:latitude":58.91944,
-    "lbl:longitude":23.52417,
+    "lbl:latitude":58.925198,
+    "lbl:longitude":23.529303,
     "lbl:max_zoom":17.0,
     "lbl:min_zoom":12.5,
     "mps:latitude":58.925198,
@@ -99,7 +99,7 @@
     "src:geom_alt":[
         "qs_pg"
     ],
-    "src:lbl_centroid":"qs_pg",
+    "src:lbl_centroid":"mapshaper",
     "src:population":"geonames",
     "woe:adm0_id":23424805,
     "woe:name_adm0":"Eesti",
@@ -145,7 +145,7 @@
     "wof:lang_x_spoken":[
         "est"
     ],
-    "wof:lastmodified":1690875849,
+    "wof:lastmodified":1694320349,
     "wof:name":"Paralepa",
     "wof:parent_id":1713308577,
     "wof:placetype":"locality",

--- a/data/112/602/050/7/1126020507.geojson
+++ b/data/112/602/050/7/1126020507.geojson
@@ -13,12 +13,12 @@
     "gn:fcode":"PPL",
     "gn:population":307,
     "iso:country":"EE",
-    "lbl:latitude":58.95,
-    "lbl:longitude":25.83333,
+    "lbl:latitude":58.94002,
+    "lbl:longitude":25.83995,
     "lbl:max_zoom":17.0,
     "lbl:min_zoom":12.5,
     "mps:latitude":58.94002,
-    "mps:longitude":25.839949,
+    "mps:longitude":25.83995,
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
@@ -93,7 +93,7 @@
     "src:geom_alt":[
         "qs_pg"
     ],
-    "src:lbl_centroid":"qs_pg",
+    "src:lbl_centroid":"mapshaper",
     "src:population":"geonames",
     "woe:adm0_id":23424805,
     "woe:name_adm0":"Eesti",
@@ -139,7 +139,7 @@
     "wof:lang_x_spoken":[
         "est"
     ],
-    "wof:lastmodified":1690875768,
+    "wof:lastmodified":1694320349,
     "wof:name":"Peetri",
     "wof:parent_id":1713307107,
     "wof:placetype":"locality",

--- a/data/112/603/206/7/1126032067.geojson
+++ b/data/112/603/206/7/1126032067.geojson
@@ -13,11 +13,11 @@
     "gn:fcode":"PPL",
     "gn:population":476,
     "iso:country":"EE",
-    "lbl:latitude":58.35222,
-    "lbl:longitude":22.04694,
+    "lbl:latitude":58.359847,
+    "lbl:longitude":22.044376,
     "lbl:max_zoom":17.0,
     "lbl:min_zoom":12.5,
-    "mps:latitude":58.359848,
+    "mps:latitude":58.359847,
     "mps:longitude":22.044376,
     "mz:hierarchy_label":1,
     "mz:is_current":1,
@@ -108,7 +108,7 @@
     "src:geom_alt":[
         "qs_pg"
     ],
-    "src:lbl_centroid":"qs_pg",
+    "src:lbl_centroid":"mapshaper",
     "src:population":"geonames",
     "woe:adm0_id":23424805,
     "woe:name_adm0":"Eesti",
@@ -154,7 +154,7 @@
     "wof:lang_x_spoken":[
         "est"
     ],
-    "wof:lastmodified":1690875793,
+    "wof:lastmodified":1694320349,
     "wof:name":"Kihelkonna",
     "wof:parent_id":1713307065,
     "wof:placetype":"locality",

--- a/data/112/603/208/9/1126032089.geojson
+++ b/data/112/603/208/9/1126032089.geojson
@@ -13,8 +13,8 @@
     "gn:fcode":"PPL",
     "gn:population":468,
     "iso:country":"EE",
-    "lbl:latitude":57.84194,
-    "lbl:longitude":26.46389,
+    "lbl:latitude":57.840445,
+    "lbl:longitude":26.474021,
     "lbl:max_zoom":17.0,
     "lbl:min_zoom":12.5,
     "mps:latitude":57.840445,
@@ -93,7 +93,7 @@
     "src:geom_alt":[
         "qs_pg"
     ],
-    "src:lbl_centroid":"qs_pg",
+    "src:lbl_centroid":"mapshaper",
     "src:population":"geonames",
     "woe:adm0_id":23424805,
     "woe:name_adm0":"Eesti",
@@ -139,7 +139,7 @@
     "wof:lang_x_spoken":[
         "est"
     ],
-    "wof:lastmodified":1690875793,
+    "wof:lastmodified":1694320349,
     "wof:name":"Kobela",
     "wof:parent_id":1713314051,
     "wof:placetype":"locality",

--- a/data/112/603/218/9/1126032189.geojson
+++ b/data/112/603/218/9/1126032189.geojson
@@ -13,8 +13,8 @@
     "gn:fcode":"PPL",
     "gn:population":450,
     "iso:country":"EE",
-    "lbl:latitude":58.25528,
-    "lbl:longitude":22.54917,
+    "lbl:latitude":58.26315,
+    "lbl:longitude":22.530778,
     "lbl:max_zoom":17.0,
     "lbl:min_zoom":12.5,
     "mps:latitude":58.26315,
@@ -99,7 +99,7 @@
     "src:geom_alt":[
         "qs_pg"
     ],
-    "src:lbl_centroid":"qs_pg",
+    "src:lbl_centroid":"mapshaper",
     "src:population":"geonames",
     "woe:adm0_id":23424805,
     "woe:name_adm0":"Eesti",
@@ -145,7 +145,7 @@
     "wof:lang_x_spoken":[
         "est"
     ],
-    "wof:lastmodified":1690875785,
+    "wof:lastmodified":1694320350,
     "wof:name":"Kudjape",
     "wof:parent_id":1713306545,
     "wof:placetype":"locality",

--- a/data/112/603/268/1/1126032681.geojson
+++ b/data/112/603/268/1/1126032681.geojson
@@ -13,8 +13,8 @@
     "gn:fcode":"PPL",
     "gn:population":990,
     "iso:country":"EE",
-    "lbl:latitude":58.95389,
-    "lbl:longitude":23.75222,
+    "lbl:latitude":58.950957,
+    "lbl:longitude":23.728288,
     "lbl:max_zoom":17.0,
     "lbl:min_zoom":12.5,
     "mps:latitude":58.950957,
@@ -105,7 +105,7 @@
     "src:geom_alt":[
         "qs_pg"
     ],
-    "src:lbl_centroid":"qs_pg",
+    "src:lbl_centroid":"mapshaper",
     "src:population":"geonames",
     "woe:adm0_id":23424805,
     "woe:name_adm0":"Eesti",
@@ -151,7 +151,7 @@
     "wof:lang_x_spoken":[
         "est"
     ],
-    "wof:lastmodified":1690875785,
+    "wof:lastmodified":1694320350,
     "wof:name":"Taebla",
     "wof:parent_id":1713309101,
     "wof:placetype":"locality",

--- a/data/112/603/778/9/1126037789.geojson
+++ b/data/112/603/778/9/1126037789.geojson
@@ -13,8 +13,8 @@
     "gn:fcode":"PPL",
     "gn:population":646,
     "iso:country":"EE",
-    "lbl:latitude":58.57833,
-    "lbl:longitude":26.27528,
+    "lbl:latitude":58.57623,
+    "lbl:longitude":26.290903,
     "lbl:max_zoom":17.0,
     "lbl:min_zoom":12.5,
     "mps:latitude":58.57623,
@@ -84,7 +84,7 @@
     "src:geom_alt":[
         "qs_pg"
     ],
-    "src:lbl_centroid":"qs_pg",
+    "src:lbl_centroid":"mapshaper",
     "src:population":"geonames",
     "woe:adm0_id":23424805,
     "woe:name_adm0":"Eesti",
@@ -129,7 +129,7 @@
     "wof:lang_x_spoken":[
         "est"
     ],
-    "wof:lastmodified":1596676507,
+    "wof:lastmodified":1694320350,
     "wof:name":"Puurmani",
     "wof:parent_id":1713312085,
     "wof:placetype":"locality",

--- a/data/112/603/908/3/1126039083.geojson
+++ b/data/112/603/908/3/1126039083.geojson
@@ -13,8 +13,8 @@
     "gn:fcode":"PPL",
     "gn:population":243,
     "iso:country":"EE",
-    "lbl:latitude":57.92528,
-    "lbl:longitude":26.315,
+    "lbl:latitude":57.923892,
+    "lbl:longitude":26.326772,
     "lbl:max_zoom":17.0,
     "lbl:min_zoom":12.5,
     "mps:latitude":57.923892,
@@ -84,7 +84,7 @@
     "src:geom_alt":[
         "qs_pg"
     ],
-    "src:lbl_centroid":"qs_pg",
+    "src:lbl_centroid":"mapshaper",
     "src:population":"geonames",
     "woe:adm0_id":23424805,
     "woe:name_adm0":"Eesti",
@@ -129,7 +129,7 @@
     "wof:lang_x_spoken":[
         "est"
     ],
-    "wof:lastmodified":1596661880,
+    "wof:lastmodified":1694320350,
     "wof:name":"Sangaste",
     "wof:parent_id":1713309947,
     "wof:placetype":"locality",

--- a/data/112/605/697/1/1126056971.geojson
+++ b/data/112/605/697/1/1126056971.geojson
@@ -13,8 +13,8 @@
     "gn:fcode":"PPL",
     "gn:population":189,
     "iso:country":"EE",
-    "lbl:latitude":59.19611,
-    "lbl:longitude":24.65861,
+    "lbl:latitude":59.210936,
+    "lbl:longitude":24.66302,
     "lbl:max_zoom":18.0,
     "lbl:min_zoom":13.0,
     "mps:latitude":59.210936,
@@ -90,7 +90,7 @@
     "src:geom_alt":[
         "qs_pg"
     ],
-    "src:lbl_centroid":"qs_pg",
+    "src:lbl_centroid":"mapshaper",
     "src:population":"geonames",
     "woe:adm0_id":23424805,
     "woe:name_adm0":"Eesti",
@@ -136,7 +136,7 @@
     "wof:lang_x_spoken":[
         "est"
     ],
-    "wof:lastmodified":1690875774,
+    "wof:lastmodified":1694320350,
     "wof:name":"Aespa",
     "wof:parent_id":1713306383,
     "wof:placetype":"locality",

--- a/data/112/605/701/7/1126057017.geojson
+++ b/data/112/605/701/7/1126057017.geojson
@@ -13,8 +13,8 @@
     "gn:fcode":"PPL",
     "gn:population":573,
     "iso:country":"EE",
-    "lbl:latitude":58.20806,
-    "lbl:longitude":26.41139,
+    "lbl:latitude":58.211895,
+    "lbl:longitude":26.400638,
     "lbl:max_zoom":17.0,
     "lbl:min_zoom":12.5,
     "mps:latitude":58.211895,
@@ -81,7 +81,7 @@
     "src:geom_alt":[
         "qs_pg"
     ],
-    "src:lbl_centroid":"qs_pg",
+    "src:lbl_centroid":"mapshaper",
     "src:population":"geonames",
     "woe:adm0_id":23424805,
     "woe:name_adm0":"Eesti",
@@ -127,7 +127,7 @@
     "wof:lang_x_spoken":[
         "est"
     ],
-    "wof:lastmodified":1690875768,
+    "wof:lastmodified":1694320350,
     "wof:name":"K\u00e4\u00e4rdi",
     "wof:parent_id":1713310627,
     "wof:placetype":"locality",

--- a/data/112/605/705/3/1126057053.geojson
+++ b/data/112/605/705/3/1126057053.geojson
@@ -13,8 +13,8 @@
     "gn:fcode":"PPL",
     "gn:population":275,
     "iso:country":"EE",
-    "lbl:latitude":59.08389,
-    "lbl:longitude":26.17333,
+    "lbl:latitude":59.090119,
+    "lbl:longitude":26.180107,
     "lbl:max_zoom":17.0,
     "lbl:min_zoom":12.5,
     "mps:latitude":59.090119,
@@ -99,7 +99,7 @@
     "src:geom_alt":[
         "qs_pg"
     ],
-    "src:lbl_centroid":"qs_pg",
+    "src:lbl_centroid":"mapshaper",
     "src:population":"geonames",
     "woe:adm0_id":23424805,
     "woe:name_adm0":"Eesti",
@@ -145,7 +145,7 @@
     "wof:lang_x_spoken":[
         "est"
     ],
-    "wof:lastmodified":1690875773,
+    "wof:lastmodified":1694320350,
     "wof:name":"Kiltsi",
     "wof:parent_id":1713311601,
     "wof:placetype":"locality",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2159.

This PR updates records with label centroids that fall outside of a geometry. The new label centroid comes from Mapshaper, the `src:lbl_centroid` property has been updated, too.

This PR will require PIP work before merge.