### PR TITLE
Update locality Tallinn

### DIFF
--- a/data/101/748/153/101748153.geojson
+++ b/data/101/748/153/101748153.geojson
@@ -174,9 +174,6 @@
         "\u03a4\u03b1\u03bb\u03b9\u03bd",
         "\u03a4\u03ac\u03bb\u03b9\u03bd"
     ],
-    "name:eng_x_colloquial":[
-        ""
-    ],
     "name:eng_x_preferred":[
         "Tallinn"
     ],
@@ -594,7 +591,7 @@
         "Lindan\u00e4s"
     ],
     "name:swe_x_preferred":[
-        "Tallin"
+        "Tallinn"
     ],
     "name:swe_x_variant":[
         "Tallinn",
@@ -845,11 +842,11 @@
     "woe:name_adm1":"Harjumaa",
     "woe:placetype":"Town",
     "wof:belongsto":[
-        85683055,
         102191581,
-        1713305847,
         85633135,
-        1713305645
+        1713305645,
+        1713305847,
+        85683055
     ],
     "wof:breaches":[],
     "wof:capital_of":[
@@ -891,7 +888,7 @@
     "wof:lang_x_spoken":[
         "est"
     ],
-    "wof:lastmodified":1690875685,
+    "wof:lastmodified":1771865398,
     "wof:megacity":0,
     "wof:name":"Tallinn",
     "wof:parent_id":1713305847,


### PR DESCRIPTION
Updating `data/101/748/153/101748153.geojson` using the [WOF Editor](https://github.com/iandees/wof-editor)

Hello, 

Fixing the Swedish translation of Tallinn (Estonia's capital):
- correct is "Tallinn" (with double 'n' ) 
- not "Tallin" (with single 'n' ) 